### PR TITLE
Various fixes

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,16 +11,30 @@ import TypeWildcardProvider from './features/typeWildcardProvider';
 
 export function activate(context: vscode.ExtensionContext)
 {
-	const providers = [
-		new ImportProvider(),
-		new QualifiedImportProvider(),
-		new OrganizeImportProvider(),
-		new ExtensionProvider(),
-		new OrganizeExtensionProvider(),
-		new TopLevelSignatureProvider(),
-		new TypedHoleProvider(),
-		new TypeWildcardProvider(),
-	];
+	let isGhcIde = vscode.extensions.getExtension('DigitalAssetHoldingsLLC.ghcide') !== undefined;
+	
+	var providers;
+	if (isGhcIde) {
+		// Do not add functionality provided by ghcide itself
+		providers = [
+			new ImportProvider(),
+			new QualifiedImportProvider(),
+			new OrganizeImportProvider(),
+			new OrganizeExtensionProvider(),
+		];
+	} else {
+		providers = [
+			new ImportProvider(),
+			new QualifiedImportProvider(),
+			new OrganizeImportProvider(),
+			new ExtensionProvider(),
+			new OrganizeExtensionProvider(),
+			new TopLevelSignatureProvider(),
+			new TypedHoleProvider(),
+			new TypeWildcardProvider(),
+		];
+  }
+
 	for (const provider of providers)
 	{
 		provider.activate(context.subscriptions);

--- a/src/features/extensionProvider/extensionDeclaration.ts
+++ b/src/features/extensionProvider/extensionDeclaration.ts
@@ -3,10 +3,12 @@ import { Range, TextDocument } from "vscode";
 export default class ExtensionDeclaration
 {
 	private _extensions?: string[] = [];
+	private _header: string = "";
 
-	constructor(extensions: string, public offset?: number, public length?: number)
+	constructor(header: string, extensions: string, public offset?: number, public length?: number)
   {
-    this.extensions = extensions;
+		this.extensions = extensions;
+		this._header = header;
 	}
 
 	public get extensions()
@@ -19,6 +21,11 @@ export default class ExtensionDeclaration
 		this._extensions = extensionsString ? extensionsString.split(',') : [];
 	}
 
+	public get header()
+	{
+		return this._header;
+	}
+
 	public get extensionNames()
 	{
 		return this._extensions.map(e => e.trim());
@@ -26,7 +33,7 @@ export default class ExtensionDeclaration
 
 	public get text()
 	{
-		return `{-# LANGUAGE ${this.extensions}#-}`;
+		return `{-# ${this.header} ${this.extensions}#-}`;
   }
 
   public getRange(document: TextDocument): Range
@@ -38,7 +45,7 @@ export default class ExtensionDeclaration
 
   public static get extensionRegex(): RegExp
 	{
-		return /^{-#\s+LANGUAGE\s+([^#]+)#-}/gm;
+		return /^{-#\s+(LANGUAGE|language)\s+([^#]+)#-}/gm;
 	}
   
   public static getExtensions(text: string): ExtensionDeclaration[]
@@ -46,7 +53,7 @@ export default class ExtensionDeclaration
     const imports = [];
 		for (let match, regex = ExtensionDeclaration.extensionRegex; match = regex.exec(text);)
 		{
-      imports.push(new ExtensionDeclaration(match[1], match.index, match[0].length));
+      imports.push(new ExtensionDeclaration(match[1], match[2], match.index, match[0].length));
 		}
 		return imports;
 	}

--- a/src/features/importProvider.ts
+++ b/src/features/importProvider.ts
@@ -19,7 +19,8 @@ export default class ImportProvider extends ImportProviderBase implements CodeAc
 		{
 			const patterns = [
 				/Variable not in scope:\s+(\S+)/,
-				/Not in scope: type constructor or class `(\S+)'/
+				/Not in scope: type constructor or class `(\S+)'/,
+				/Not in scope: type constructor or class ‘(\S+)’/
 			];
 			for (const pattern of patterns)
 			{

--- a/src/features/organizeExtensionProvider.ts
+++ b/src/features/organizeExtensionProvider.ts
@@ -162,7 +162,8 @@ export default class OrganizeExtensionProvider implements CodeActionProvider
       const range = extension.getRange(document);
       edit.delete(document.uri, range.with({ end: range.end.with(range.end.line + 1, 0) }));
 
-      const extensions = extension.extensionNames.map(name => new ExtensionDeclaration(`${name} `));
+      const extensions = extension.extensionNames.map(name =>
+        new ExtensionDeclaration(extension.header, `${name} `));
       extensions.sort((l, r) => r.text.localeCompare(l.text));
       for (const newExtension of extensions)
       {
@@ -177,7 +178,7 @@ export default class OrganizeExtensionProvider implements CodeActionProvider
     const oldExtensions = ExtensionDeclaration.getExtensions(document.getText());
     const length = Math.max(...oldExtensions.map(extension => extension.extensions.length));
     const newExtensions = oldExtensions.map(extension =>
-      new ExtensionDeclaration(extension.extensions.concat(" ".repeat(length - extension.extensions.length))));
+      new ExtensionDeclaration(extension.header, extension.extensions.concat(" ".repeat(length - extension.extensions.length))));
     
     var edit = new WorkspaceEdit();
     for (let i = oldExtensions.length - 1; i >= 0; i--)

--- a/src/features/organizeImportProvider.ts
+++ b/src/features/organizeImportProvider.ts
@@ -56,7 +56,8 @@ export default class OrganizeImportProvider implements CodeActionProvider
       vscode.window.showWarningMessage(
         "Dependent extension which populates diagnostics (Errors and Warnings) is not installed.\n" +
         "Please install either [Simple GHC](https://marketplace.visualstudio.com/items?itemName=dramforever.vscode-ghc-simple) " +
-        "or [Haskero](https://marketplace.visualstudio.com/items?itemName=Vans.haskero) to enable all features.");
+        "or [Haskero](https://marketplace.visualstudio.com/items?itemName=Vans.haskero) " +
+        "or [ghcide](https://github.com/digital-asset/ghcide) to enable all features.");
     }
   }
 
@@ -71,7 +72,8 @@ export default class OrganizeImportProvider implements CodeActionProvider
   {
     const dependency =
       vscode.extensions.getExtension('dramforever.vscode-ghc-simple') ||
-      vscode.extensions.getExtension('Vans.haskero');
+      vscode.extensions.getExtension('Vans.haskero') ||
+      vscode.extensions.getExtension('DigitalAssetHoldingsLLC.ghcide');
     return dependency !== undefined;    
   }
 


### PR DESCRIPTION
This is a set of fixes I've done for my local set-up, which I think can be interesting to others:

- In some GHC versions and OSes the "missing import" message uses different quotes. Now the extension works with any of them.
- Extensions were only recognized with `LANGUAGE`, but lower-case `language` may also be used. Now the extension works with any of them, and respects the programmers' choice.
- The newer `ghcide` extension may now also be used as source of diagnostics. Since that extension already provides some of the functionality of Haskutil, only the additional functionality is added in that case.

It would be great if a new version of the extension could be published with these changes :)