### PR TITLE
Make extension more careful on which documents to work on

### DIFF
--- a/src/features/extensionProvider.ts
+++ b/src/features/extensionProvider.ts
@@ -3,6 +3,7 @@
 import { CodeActionProvider, Disposable, TextDocument, Range, CodeActionContext, CancellationToken, CodeAction, WorkspaceEdit, CodeActionKind, WorkspaceConfiguration } from 'vscode';
 import * as vscode from 'vscode';
 import OrganizeExtensionProvider from './organizeExtensionProvider';
+import { documentInScope } from './utils';
 
 
 export default class ExtensionProvider implements CodeActionProvider {
@@ -35,6 +36,10 @@ export default class ExtensionProvider implements CodeActionProvider {
   }
 
   public async provideCodeActions(document: TextDocument, range: Range, context: CodeActionContext, token: CancellationToken): Promise<any> {
+    if (! documentInScope(document)) {
+      return;
+    }
+
     const codeActions = [];
     for (const diagnostic of context.diagnostics) {
       for (const extension of ExtensionProvider.extensions) {

--- a/src/features/importProvider.ts
+++ b/src/features/importProvider.ts
@@ -3,6 +3,7 @@
 import { CodeActionProvider, TextDocument, Range, CodeActionContext, CancellationToken, CodeAction, CodeActionKind } from 'vscode';
 import * as vscode from 'vscode';
 import ImportProviderBase, { SearchResult } from './importProvider/importProviderBase';
+import { documentInScope } from './utils';
 
 
 export default class ImportProvider extends ImportProviderBase implements CodeActionProvider {
@@ -11,6 +12,10 @@ export default class ImportProvider extends ImportProviderBase implements CodeAc
   }
 
   public async provideCodeActions(document: TextDocument, range: Range, context: CodeActionContext, token: CancellationToken): Promise<any> {
+    if (! documentInScope(document)) {
+      return;
+    }
+
     let codeActions = [];
     for (const diagnostic of context.diagnostics.filter(d => d.severity === vscode.DiagnosticSeverity.Error)) {
       const patterns = [

--- a/src/features/organizeExtensionProvider.ts
+++ b/src/features/organizeExtensionProvider.ts
@@ -3,6 +3,7 @@
 import { CodeActionProvider, Disposable, TextDocument, Range, CodeActionContext, CancellationToken, CodeAction, WorkspaceEdit, CodeActionKind, Diagnostic, DiagnosticSeverity, WorkspaceConfiguration, TextDocumentWillSaveEvent } from 'vscode';
 import * as vscode from 'vscode';
 import ExtensionDeclaration from './extensionProvider/extensionDeclaration';
+import { documentInScope } from './utils';
 
 
 export default class OrganizeExtensionProvider implements CodeActionProvider {
@@ -51,6 +52,10 @@ export default class OrganizeExtensionProvider implements CodeActionProvider {
   }
 
   private checkExtensions(document: TextDocument) {
+    if (! documentInScope(document)) {
+      return;
+    }
+
     const extensions = ExtensionDeclaration.getExtensions(document.getText());
 
     let unorganized =
@@ -89,6 +94,10 @@ export default class OrganizeExtensionProvider implements CodeActionProvider {
   }
 
   public async provideCodeActions(document: TextDocument, range: Range, context: CodeActionContext, token: CancellationToken): Promise<CodeAction[]> {
+    if (! documentInScope(document)) {
+      return;
+    }
+
     let codeActions = [];
     for (let diagnostic of context.diagnostics.filter(d => d.code === OrganizeExtensionProvider.diagnosticCode)) {
       let title = "Organize extensions";
@@ -119,6 +128,10 @@ export default class OrganizeExtensionProvider implements CodeActionProvider {
   }
 
   private ensureOrganized(event: TextDocumentWillSaveEvent) {
+    if (! documentInScope(event.document)) {
+      return;
+    }
+
     if (OrganizeExtensionProvider.shouldOrganizeExtensionsOnSave) {
       event.waitUntil(this.runCodeAction(event.document));
     }

--- a/src/features/organizeImportProvider.ts
+++ b/src/features/organizeImportProvider.ts
@@ -3,6 +3,7 @@
 import { CodeActionProvider, Disposable, TextDocument, Range, CodeActionContext, CancellationToken, CodeAction, WorkspaceEdit, CodeActionKind, Diagnostic, DiagnosticSeverity, WorkspaceConfiguration, TextDocumentWillSaveEvent } from 'vscode';
 import * as vscode from 'vscode';
 import ImportDeclaration from './importProvider/importDeclaration';
+import { documentInScope } from './utils';
 
 
 export default class OrganizeImportProvider implements CodeActionProvider {
@@ -52,6 +53,10 @@ export default class OrganizeImportProvider implements CodeActionProvider {
   }
 
   private checkImports(document: TextDocument) {
+    if (! documentInScope(document)) {
+      return;
+    }
+
     const imports = ImportDeclaration.getImports(document.getText());
     let messages = [];
 
@@ -134,6 +139,10 @@ export default class OrganizeImportProvider implements CodeActionProvider {
   }
 
   private ensureOrganized(event: TextDocumentWillSaveEvent) {
+    if (! documentInScope(event.document)) {
+      return;
+    }
+
     if (OrganizeImportProvider.shouldOrganizeImportsOnSave) {
       event.waitUntil(this.runCodeAction(event.document));
     }

--- a/src/features/qualifiedImportProvider.ts
+++ b/src/features/qualifiedImportProvider.ts
@@ -3,6 +3,7 @@
 import { CodeActionProvider, TextDocument, Range, CodeActionContext, CancellationToken, CodeAction, CodeActionKind } from 'vscode';
 import * as vscode from 'vscode';
 import ImportProviderBase, { SearchResult } from './importProvider/importProviderBase';
+import { documentInScope } from './utils';
 
 
 export default class QualifiedImportProvider extends ImportProviderBase implements CodeActionProvider {
@@ -11,6 +12,10 @@ export default class QualifiedImportProvider extends ImportProviderBase implemen
   }
 
   public async provideCodeActions(document: TextDocument, range: Range, context: CodeActionContext, token: CancellationToken): Promise<any> {
+    if (! documentInScope(document)) {
+      return;
+    }
+
     const pattern = /Not in scope:[^`]*[`‘]([^.]+)\.([^'’]+)['’]/;
     let codeActions = [];
     for (let diagnostic of context.diagnostics.filter(d => d.severity === vscode.DiagnosticSeverity.Error)) {

--- a/src/features/topLevelSignatureProvider.ts
+++ b/src/features/topLevelSignatureProvider.ts
@@ -2,6 +2,7 @@
 
 import { CodeActionProvider, Disposable, TextDocument, Range, CodeActionContext, CancellationToken, CodeAction, WorkspaceEdit, CodeActionKind } from 'vscode';
 import * as vscode from 'vscode';
+import { documentInScope } from './utils';
 
 
 export default class TopLevelSignatureProvider implements CodeActionProvider {
@@ -18,6 +19,10 @@ export default class TopLevelSignatureProvider implements CodeActionProvider {
   }
 
   public async provideCodeActions(document: TextDocument, range: Range, context: CodeActionContext, token: CancellationToken): Promise<any> {
+    if (! documentInScope(document)) {
+      return;
+    }
+
     const pattern = /Top-level binding with no type signature:\s+([^]+)/;
     const codeActions = [];
     for (const diagnostic of context.diagnostics) {

--- a/src/features/typeWildcardProvider.ts
+++ b/src/features/typeWildcardProvider.ts
@@ -2,6 +2,7 @@
 
 import { CodeActionProvider, Disposable, TextDocument, Range, CodeActionContext, CancellationToken, CodeAction, WorkspaceEdit, CodeActionKind } from 'vscode';
 import * as vscode from 'vscode';
+import { documentInScope } from './utils';
 
 
 export default class TypeWildcardProvider implements CodeActionProvider {
@@ -18,6 +19,10 @@ export default class TypeWildcardProvider implements CodeActionProvider {
   }
 
   public async provideCodeActions(document: TextDocument, range: Range, context: CodeActionContext, token: CancellationToken): Promise<any> {
+    if (! documentInScope(document)) {
+      return;
+    }
+
     const errorPattern = / Found type wildcard [`‘](.+?)['’]/;
     const fillPattern = /standing for [`‘](.+?)['’]/;
     const codeActions = [];

--- a/src/features/typedHoleProvider.ts
+++ b/src/features/typedHoleProvider.ts
@@ -2,6 +2,7 @@
 
 import { CodeActionProvider, Disposable, TextDocument, Range, CodeActionContext, CancellationToken, CodeAction, WorkspaceEdit, CodeActionKind } from 'vscode';
 import * as vscode from 'vscode';
+import { documentInScope } from './utils';
 
 
 export default class TypedHoleProvider implements CodeActionProvider {
@@ -18,6 +19,10 @@ export default class TypedHoleProvider implements CodeActionProvider {
   }
 
   public async provideCodeActions(document: TextDocument, range: Range, context: CodeActionContext, token: CancellationToken): Promise<any> {
+    if (! documentInScope(document)) {
+      return;
+    }
+
     const errorPattern = / Found hole: ([^\s]+?) ::/;
     const fillPattern = /^\s+([^\s]+)\s::/gm;
     const codeActions = [];

--- a/src/features/utils.ts
+++ b/src/features/utils.ts
@@ -1,0 +1,12 @@
+import { TextDocument } from "vscode";
+
+export function documentInScope(document: TextDocument) {
+    const { languageId } = document;
+    const { path } = document.uri;
+    return (
+        languageId === 'haskell' ||
+        languageId === 'literate haskell' ||
+        path.endsWith('.hs') ||
+        path.endsWith('.lhs')
+    );
+}


### PR DESCRIPTION
- Providers are only run if the current document is indeed a Haskell document
- When diagnostics change, delay `openTextDocument` until we know for sure there are unused imports.

These prevents problems like: (Open a Haskell file to activate extension before trying)

- Haskutil complaining about a Python file with unorganized imports
- Untitled files re-opening themselves after closing

Tried on VSCode 1.44.1, Haskutil 0.8.0