### PR TITLE
Fix `Organize imports` (language) & `Remove unused imports` (Untitled)

### DIFF
--- a/src/features/organizeImportProvider.ts
+++ b/src/features/organizeImportProvider.ts
@@ -40,9 +40,9 @@ export default class OrganizeImportProvider implements CodeActionProvider {
     this.diagnosticCollection = vscode.languages.createDiagnosticCollection();
     vscode.workspace.onDidOpenTextDocument(this.checkImports, this, subscriptions);
     vscode.workspace.onDidCloseTextDocument(doc => this.diagnosticCollection.delete(doc.uri), null, subscriptions);
-    vscode.workspace.onDidSaveTextDocument(this.checkImports, this);
-    vscode.workspace.onWillSaveTextDocument(this.ensureOrganized, this);
-    vscode.workspace.textDocuments.forEach(this.checkImports, this);
+    vscode.workspace.onDidSaveTextDocument(this.checkImports, this, subscriptions);
+    vscode.workspace.onWillSaveTextDocument(this.ensureOrganized, this, subscriptions);
+    vscode.workspace.textDocuments.filter(d => d.languageId === 'haskell').forEach(this.checkImports, this);
   }
 
   public dispose(): void {
@@ -52,6 +52,10 @@ export default class OrganizeImportProvider implements CodeActionProvider {
   }
 
   private checkImports(document: TextDocument) {
+    // We subscribe to multiple events which can be fired for any language, not just `Haskell` 
+    if (document.languageId !== 'haskell') {
+      return;
+    }
     const imports = ImportDeclaration.getImports(document.getText());
     let messages = [];
 

--- a/src/features/removeUnusedImportProvider.ts
+++ b/src/features/removeUnusedImportProvider.ts
@@ -1,6 +1,6 @@
 'use strict';
 
-import { CodeActionProvider, Disposable, TextDocument, Range, CodeActionContext, CancellationToken, CodeAction, WorkspaceEdit, CodeActionKind, Diagnostic, DiagnosticSeverity, DiagnosticChangeEvent } from 'vscode';
+import { CodeActionProvider, Disposable, TextDocument, Range, CodeActionContext, CancellationToken, CodeAction, WorkspaceEdit, CodeActionKind, Diagnostic, DiagnosticSeverity, DiagnosticChangeEvent, Uri } from 'vscode';
 import * as vscode from 'vscode';
 import ImportDeclaration from './importProvider/importDeclaration';
 import OrganizeImportProvider from './organizeImportProvider';
@@ -27,9 +27,9 @@ export default class RemoveUnusedImportProvider implements CodeActionProvider {
 
   private async didChangeDiagnostics(e: DiagnosticChangeEvent) {
     for (const uri of e.uris) {
-      const document = await vscode.workspace.openTextDocument(uri);
-      const unusedImports = this.getUnusedImports(document);
+      const unusedImports = this.getUnusedImports(uri);
       if (unusedImports.length) {
+        const document = await vscode.workspace.openTextDocument(uri);
         const imports = ImportDeclaration.getImports(document.getText());
         const lastImport = imports[imports.length - 1];
         const range = new Range(
@@ -42,8 +42,8 @@ export default class RemoveUnusedImportProvider implements CodeActionProvider {
           this.diagnosticCollection.set(document.uri, [diagnostic]);
         }
       }
-      else if (!unusedImports.length && this.diagnosticCollection.has(document.uri)) {
-        this.diagnosticCollection.delete(document.uri);
+      else if (!unusedImports.length && this.diagnosticCollection.has(uri)) {
+        this.diagnosticCollection.delete(uri);
       }
     }
   }
@@ -70,7 +70,8 @@ export default class RemoveUnusedImportProvider implements CodeActionProvider {
     const edit = new WorkspaceEdit();
     let imports = ImportDeclaration.getImports(document.getText());
     const toBeDeleted = [];
-    for (const [range, start,,, list] of this.getUnusedImports(document)) {
+    for (const [range,,, list] of this.getUnusedImports(document.uri)) {
+      const start = document.offsetAt(range.start);
       const oldImportIndex = imports.findIndex(i => i.offset === start);
       const oldImport = imports[oldImportIndex];
       if(list) {
@@ -93,8 +94,8 @@ export default class RemoveUnusedImportProvider implements CodeActionProvider {
     return vscode.workspace.applyEdit(edit);
   }
 
-  private getUnusedImports(document: TextDocument): [Range, number, ...string[]][] {
-    const diagnostics = vscode.languages.getDiagnostics(document.uri);
+  private getUnusedImports(uri: Uri): [Range, ...string[]][] {
+    const diagnostics = vscode.languages.getDiagnostics(uri);
     return diagnostics
       .map(d => [
         d.range,
@@ -103,7 +104,6 @@ export default class RemoveUnusedImportProvider implements CodeActionProvider {
       .filter(([,m]) => m)
       .map(([range, match]) => [
         range,
-        document.offsetAt(range.start),
         ...match
       ]);
   }


### PR DESCRIPTION
Takes a part of #27 (thanks, @dramforever!):
 - Issue: Untitled files re-opening themselves after closing. Solution: When diagnostics change, delay openTextDocument until we know for sure there are unused imports

Also fixes :
 - Haskutil complaining about a Python file with unorganized imports
But does it in a different way: Since `CodeActionProvider` [is registered](https://github.com/EduardSergeev/vscode-haskutil/pull/27#issuecomment-616290991) for a specific language anyway we don't need to do an explicit check ourselves.  
The root of the observed behaviour is that we simply incorrectly [run the check for all opened files](https://github.com/EduardSergeev/vscode-haskutil/blob/bf2cbdc0a973853280033c37a60fa83a80e5d77e/src/features/organizeImportProvider.ts#L45) right during `activate` event so any non-haskell file can receive this "Unorganized imports" diagnostic message and for some reason this message then "sticks" to a file (~not sure why~ ~I suspect because after the initial check the provider is never called after that so no one can remove the diagnostic~ because we also run the check for every doc's operation *regardless of the doc's language*) - after the `activation` this code provider is never called for `python` file but the diagnostics stays attached to it.  
Make sure we run it for `haskell` files only now.