### PR TITLE
More test coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ jobs:
   - os: osx
     if: branch = master
 
-script: npm install && npm test
+script: npm install && npm run coverage
 
 after_success: npm run coveralls
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Change Log
 All notable changes to the "Haskutil" extension will be documented in this file.
 
+## [0.10.0] - 2020-05-09
+### Added
+ * `haskutil.organiseImportsOnInsert` configuration option
+ ### Fixed
+ * Run multiple Hoogle requests in parallel
+
 ## [0.9.2] - 2020-05-04
 ### Added
  * Test coverage

--- a/input/Welcome.hs
+++ b/input/Welcome.hs
@@ -1,0 +1,4 @@
+
+foo :: Ord a => [a] -> Maybe [a]
+foo xs =
+  listToMaybe . tails. sort $ xs 

--- a/input/after/ExtensionProvider.hs
+++ b/input/after/ExtensionProvider.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE TupleSections    #-}
 {-# LANGUAGE TypeApplications #-}
 
+foo :: String -> [(Int, Bool)]
 foo xs =
   map (, True) . read @ [Int] $ xs

--- a/input/after/ExtensionProvider.hs
+++ b/input/after/ExtensionProvider.hs
@@ -1,4 +1,5 @@
+{-# LANGUAGE TupleSections    #-}
 {-# LANGUAGE TypeApplications #-}
 
 foo xs =
-  read @ Int xs
+  map (, True) . read @ [Int] $ xs

--- a/input/after/QualifiedImportProvider.hs
+++ b/input/after/QualifiedImportProvider.hs
@@ -1,4 +1,5 @@
 import qualified Data.ByteString as BS
+import           Data.Word
 
 foo xs =
   BS.pack xs

--- a/input/after/UnusedImportProvider.hs
+++ b/input/after/UnusedImportProvider.hs
@@ -1,12 +1,5 @@
-{-# LANGUAGE NoImplicitPrelude #-}
+import Data.List (sort)
 
-module Main where
-
--- Some comment
-import Control.Monad
-import System.IO
-
-
-main :: IO ()
-main =
-  return ()
+foo :: Ord a => [a] -> [a]
+foo xs =
+  sort xs 

--- a/input/before/ExtensionProvider.hs
+++ b/input/before/ExtensionProvider.hs
@@ -1,3 +1,4 @@
 
+foo :: String -> [(Int, Bool)]
 foo xs =
   map (, True) . read @ [Int] $ xs

--- a/input/before/ExtensionProvider.hs
+++ b/input/before/ExtensionProvider.hs
@@ -1,3 +1,3 @@
 
 foo xs =
-  read @ Int xs
+  map (, True) . read @ [Int] $ xs

--- a/input/before/QualifiedImportProvider.hs
+++ b/input/before/QualifiedImportProvider.hs
@@ -1,3 +1,4 @@
+import Data.Word
 
 foo xs =
   BS.pack xs

--- a/input/before/UnusedImportProvider.hs
+++ b/input/before/UnusedImportProvider.hs
@@ -1,19 +1,6 @@
-{-# LANGUAGE NoImplicitPrelude #-}
+import Data.List (sort, tails)
+import Data.Maybe
 
-module Main where
-
--- Some comment
-import           Control.Monad
-import qualified Data.ByteString.Lazy as M
-import           Data.List
-import           Data.Maybe (
-    Maybe, 
-    listToMaybe
-  )
-import           Prelude (Ord, ($), (.))
-import           System.IO
-
-
-main :: IO ()
-main =
-  return ()
+foo :: Ord a => [a] -> [a]
+foo xs =
+  sort xs 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "haskutil",
-    "version": "0.9.2",
+    "version": "0.10.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -181,7 +181,7 @@
   ],
   "scripts": {
     "vscode:prepublish": "npm run compile",
-    "compile": "tsc -p ./",
+    "compile": "rm -rf ./out && tsc -p ./",
     "watch": "tsc -watch -p ./",
     "test": "npm run compile && mocha ./out/test/runTest.js",
     "coverage": "nyc npm test",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "haskutil",
   "displayName": "Haskutil",
   "description": "'QuickFix' actions for Haskell editor",
-  "version": "0.9.2",
+  "version": "0.10.0",
   "publisher": "Edka",
   "repository": {
     "url": "https://github.com/EduardSergeev/vscode-haskutil"

--- a/package.json
+++ b/package.json
@@ -105,6 +105,11 @@
           "description": "Organize imports on save",
           "default": false
         },
+        "haskutil.organiseImportsOnInsert": {
+          "type": "boolean",
+          "description": "Organize imports when adding new import",
+          "default": true
+        },
         "haskutil.feature.removeUnusedImport": {
           "type": "boolean",
           "default": true,

--- a/package.json
+++ b/package.json
@@ -185,7 +185,7 @@
     "watch": "tsc -watch -p ./",
     "test": "npm run compile && mocha ./out/test/runTest.js",
     "coverage": "nyc npm test",
-    "coveralls": "nyc --reporter=text-lcov npm test | coveralls"
+    "coveralls": "cat ./out/coverage/lcov.info | coveralls"
   },
   "nyc": {
     "extends": "@istanbuljs/nyc-config-typescript",

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -1,0 +1,51 @@
+import * as vscode from 'vscode';
+
+export default class Configuration {
+  public static get shouldOrganiseImportsOnInsert(): boolean {
+    return configuration().get("organiseImportsOnInsert");
+  }
+
+  public static get shouldOrganiseExtensionOnInsert(): boolean {
+    return configuration().get("organiseExtensionOnInsert");
+  }
+
+  public static get supportedExtensions(): string[] {
+    return configuration().get("supportedExtensions");
+  }
+
+  public static get shouldSplitExtensions(): boolean {
+    return configuration().get("splitExtensions");
+  }
+
+  public static get shouldAlignExtensions(): boolean {
+    return configuration().get("alignExtensions");
+  }
+
+  public static get shouldSortExtensions(): boolean {
+    return configuration().get("sortExtensions");
+  }
+
+  public static get shouldOrganizeExtensionsOnSave(): boolean {
+    return configuration().get("organiseExtensionOnSave");
+  }
+
+  public static get shouldAlignImports(): boolean {
+    return configuration().get("alignImports");
+  }
+
+  public static get shouldPadImports(): boolean {
+    return configuration().get("alwaysPadImports");
+  }
+
+  public static get shouldSortImports(): boolean {
+    return configuration().get("sortImports");
+  }
+
+  public static get shouldOrganizeImportsOnSave(): boolean {
+    return configuration().get("organiseImportsOnSave");
+  }
+}
+
+function configuration() {
+  return vscode.workspace.getConfiguration("haskutil");  
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -41,14 +41,13 @@ function checkDependencies() {
     ['ndmitchell.haskell-ghcid', 'ghcid'],
     ['digitalassetholdingsllc.ghcide', 'ghcide']
   ];
-  const installed = new Set(vscode.extensions.all.map(e => e.id));
-  if(!dependencies.find(([id]) => installed.has(id))) {
-    const ml = ([id, name]) => `[${name}](https://marketplace.visualstudio.com/items?itemName=${id})`;
-    const items = dependencies.map(ml);
+  if(!dependencies.find(([id]) => vscode.extensions.getExtension(id))) {
+    const toLink = ([id, name]) => `[${name}](https://marketplace.visualstudio.com/items?itemName=${id})`;
+    const items = dependencies.map(toLink);
     vscode.window.showWarningMessage(`Dependency is not installed.
       Extension which populates diagnostics (Errors and Warnings) is not installed.
       Please install either ${items.slice(0, -1).join(', ')} or ${items.pop()}
-      to get the full set of QuickFix actions provided by ${ml(['edka.haskutil','Haskutil'])}.
+      to get the full set of QuickFix actions provided by ${toLink(['edka.haskutil','Haskutil'])}.
     `);
   }  
 }

--- a/src/features/extensionProvider.ts
+++ b/src/features/extensionProvider.ts
@@ -19,7 +19,7 @@ export default class ExtensionProvider implements CodeActionProvider {
 
   public provideCodeActions(document: TextDocument, range: Range, context: CodeActionContext, token: CancellationToken): CodeAction[] {
     const codeActions = [];
-    for (const diagnostic of context.diagnostics.filter(d => range.contains(d.range))) {
+    for (const diagnostic of context.diagnostics) {
       for (const extension of Configuration.supportedExtensions) {
         if (!diagnostic.message.includes(extension)) {
           continue;

--- a/src/features/extensionProvider.ts
+++ b/src/features/extensionProvider.ts
@@ -84,7 +84,7 @@ export default class ExtensionProvider implements CodeActionProvider {
     await vscode.workspace.applyEdit(edit);
 
     if (ExtensionProvider.shouldOrganizeExtensionsOnInsert) {
-      vscode.commands.executeCommand(OrganizeExtensionProvider.commandId, document);
+      await vscode.commands.executeCommand(OrganizeExtensionProvider.commandId, document);
     }
   }
 }

--- a/src/features/extensionProvider.ts
+++ b/src/features/extensionProvider.ts
@@ -1,9 +1,8 @@
-'use strict';
-
-import { CodeActionProvider, Disposable, TextDocument, Range, CodeActionContext, CancellationToken, CodeAction, WorkspaceEdit, CodeActionKind, WorkspaceConfiguration } from 'vscode';
 import * as vscode from 'vscode';
+import { CodeActionProvider, Disposable, TextDocument, Range, CodeActionContext, CancellationToken, CodeAction, WorkspaceEdit, CodeActionKind } from 'vscode';
 import OrganizeExtensionProvider from './organizeExtensionProvider';
 import Configuration from '../configuration';
+import { promisify } from 'util';
 
 
 export default class ExtensionProvider implements CodeActionProvider {
@@ -18,9 +17,9 @@ export default class ExtensionProvider implements CodeActionProvider {
     subscriptions.push(command);
   }
 
-  public async provideCodeActions(document: TextDocument, range: Range, context: CodeActionContext, token: CancellationToken): Promise<any> {
+  public provideCodeActions(document: TextDocument, range: Range, context: CodeActionContext, token: CancellationToken): CodeAction[] {
     const codeActions = [];
-    for (const diagnostic of context.diagnostics) {
+    for (const diagnostic of context.diagnostics.filter(d => range.contains(d.range))) {
       for (const extension of Configuration.supportedExtensions) {
         if (!diagnostic.message.includes(extension)) {
           continue;

--- a/src/features/extensionProvider.ts
+++ b/src/features/extensionProvider.ts
@@ -7,19 +7,14 @@ import OrganizeExtensionProvider from './organizeExtensionProvider';
 
 export default class ExtensionProvider implements CodeActionProvider {
   private static commandId: string = 'haskell.addExtension';
-  private command: Disposable;
 
   public static get extensionPattern() {
     return /^{-#\s+LANGUAGE\s+([^#]+)#-}/gm;
   }
 
   public activate(subscriptions: Disposable[]) {
-    this.command = vscode.commands.registerCommand(ExtensionProvider.commandId, this.runCodeAction, this);
-    subscriptions.push(this);
-  }
-
-  public dispose(): void {
-    this.command.dispose();
+    const command = vscode.commands.registerCommand(ExtensionProvider.commandId, this.runCodeAction, this);
+    subscriptions.push(command);
   }
 
   private static get shouldOrganizeExtensionsOnInsert(): boolean {

--- a/src/features/extensionProvider.ts
+++ b/src/features/extensionProvider.ts
@@ -3,6 +3,7 @@
 import { CodeActionProvider, Disposable, TextDocument, Range, CodeActionContext, CancellationToken, CodeAction, WorkspaceEdit, CodeActionKind, WorkspaceConfiguration } from 'vscode';
 import * as vscode from 'vscode';
 import OrganizeExtensionProvider from './organizeExtensionProvider';
+import Configuration from '../configuration';
 
 
 export default class ExtensionProvider implements CodeActionProvider {
@@ -17,22 +18,10 @@ export default class ExtensionProvider implements CodeActionProvider {
     subscriptions.push(command);
   }
 
-  private static get shouldOrganizeExtensionsOnInsert(): boolean {
-    return ExtensionProvider.configuration.get("organiseExtensionOnInsert");
-  }
-
-  private static get extensions(): string[] {
-    return ExtensionProvider.configuration.get("supportedExtensions");
-  }
-
-  private static get configuration(): WorkspaceConfiguration {
-    return vscode.workspace.getConfiguration("haskutil");
-  }
-
   public async provideCodeActions(document: TextDocument, range: Range, context: CodeActionContext, token: CancellationToken): Promise<any> {
     const codeActions = [];
     for (const diagnostic of context.diagnostics) {
-      for (const extension of ExtensionProvider.extensions) {
+      for (const extension of Configuration.supportedExtensions) {
         if (!diagnostic.message.includes(extension)) {
           continue;
         }
@@ -78,7 +67,7 @@ export default class ExtensionProvider implements CodeActionProvider {
     edit.insert(document.uri, document.positionAt(position), extensionLine + "\n");
     await vscode.workspace.applyEdit(edit);
 
-    if (ExtensionProvider.shouldOrganizeExtensionsOnInsert) {
+    if (Configuration.shouldOrganiseExtensionOnInsert) {
       await vscode.commands.executeCommand(OrganizeExtensionProvider.commandId, document);
     }
   }

--- a/src/features/importProvider.ts
+++ b/src/features/importProvider.ts
@@ -13,7 +13,7 @@ export default class ImportProvider extends ImportProviderBase implements CodeAc
       /Not in scope: type constructor or class [`‘](\S+)['’]/
     ];
     const codeActions = await Promise.all(context.diagnostics
-      .filter(d => range.contains(d.range) && d.severity === DiagnosticSeverity.Error)
+      .filter(d => d.severity === DiagnosticSeverity.Error)
       .flatMap(diagnostic =>
         patterns.map(pattern => pattern.exec(diagnostic.message))
         .filter(match => match)

--- a/src/features/importProvider/importProviderBase.ts
+++ b/src/features/importProvider/importProviderBase.ts
@@ -1,10 +1,9 @@
-'use strict';
-
-import { Disposable, TextDocument, Range, WorkspaceEdit } from 'vscode';
 import * as vscode from 'vscode';
+import { Disposable, TextDocument, Range, WorkspaceEdit } from 'vscode';
 import ExtensionProvider from '../extensionProvider';
 import ImportDeclaration from './importDeclaration';
 import OrganizeImportProvider from '../organizeImportProvider';
+import Configuration from '../../configuration';
 
 
 export interface SearchResult {
@@ -58,7 +57,7 @@ export default class ImportProviderBase {
     return result;
   }
 
-  private runCodeAction(document: TextDocument, moduleName: string, options: { alias?: string, elementName?: string } = {}): Thenable<boolean> {
+  private async runCodeAction(document: TextDocument, moduleName: string, options: { alias?: string, elementName?: string } = {}): Promise<void> {
     function afterMatch(offset) {
       const position = document.positionAt(offset);
       return document.offsetAt(position.with(position.line + 1, 0));
@@ -112,7 +111,10 @@ export default class ImportProviderBase {
       edit.insert(document.uri, document.positionAt(position), importDeclaration.text + "\n");
     }
 
-    return vscode.workspace.applyEdit(edit);
+    await vscode.workspace.applyEdit(edit);
+    if(Configuration.shouldOrganiseImportsOnInsert) {
+      await vscode.commands.executeCommand(OrganizeImportProvider.commandId, document);
+    }
   }
 }
 

--- a/src/features/importProvider/importProviderBase.ts
+++ b/src/features/importProvider/importProviderBase.ts
@@ -15,23 +15,18 @@ export interface SearchResult {
 
 export default class ImportProviderBase {
   private static modulePattern = /^module(.|\n)+?where/m;
-  private command: Disposable;
   private hoogleSearch: (name: string, resultCallback: HoogleSearchCallback) => void;
 
   constructor(protected commandId: string) {
   }
 
   public activate(subscriptions: Disposable[]) {
-    this.command = vscode.commands.registerCommand(this.commandId, this.runCodeAction, this);
-    subscriptions.push(this);
+    const command = vscode.commands.registerCommand(this.commandId, this.runCodeAction, this);
+    subscriptions.push(command);
 
     const hoogle = vscode.extensions.getExtension('jcanero.hoogle-vscode');
     const hoogleApi = hoogle.exports;
     this.hoogleSearch = hoogleApi.search;
-  }
-
-  public dispose(): void {
-    this.command.dispose();
   }
 
   protected search(name: string): Promise<SearchResult[]> {

--- a/src/features/organizeExtensionProvider.ts
+++ b/src/features/organizeExtensionProvider.ts
@@ -64,9 +64,7 @@ export default class OrganizeExtensionProvider implements CodeActionProvider {
 
   public async provideCodeActions(document: TextDocument, range: Range, context: CodeActionContext, token: CancellationToken): Promise<CodeAction[]> {
     let codeActions = [];
-    const diagnostics = context.diagnostics.filter(d =>
-      range.contains(d.range) && d.code === OrganizeExtensionProvider.diagnosticCode
-    );
+    const diagnostics = context.diagnostics.filter(d => d.code === OrganizeExtensionProvider.diagnosticCode);
     for (let diagnostic of diagnostics) {
       let title = "Organize extensions";
       let codeAction = new CodeAction(title, CodeActionKind.QuickFix);

--- a/src/features/organizeExtensionProvider.ts
+++ b/src/features/organizeExtensionProvider.ts
@@ -64,7 +64,10 @@ export default class OrganizeExtensionProvider implements CodeActionProvider {
 
   public async provideCodeActions(document: TextDocument, range: Range, context: CodeActionContext, token: CancellationToken): Promise<CodeAction[]> {
     let codeActions = [];
-    for (let diagnostic of context.diagnostics.filter(d => d.code === OrganizeExtensionProvider.diagnosticCode)) {
+    const diagnostics = context.diagnostics.filter(d =>
+      range.contains(d.range) && d.code === OrganizeExtensionProvider.diagnosticCode
+    );
+    for (let diagnostic of diagnostics) {
       let title = "Organize extensions";
       let codeAction = new CodeAction(title, CodeActionKind.QuickFix);
       codeAction.command = {

--- a/src/features/organizeExtensionProvider.ts
+++ b/src/features/organizeExtensionProvider.ts
@@ -3,33 +3,13 @@
 import { CodeActionProvider, Disposable, TextDocument, Range, CodeActionContext, CancellationToken, CodeAction, WorkspaceEdit, CodeActionKind, Diagnostic, DiagnosticSeverity, WorkspaceConfiguration, TextDocumentWillSaveEvent } from 'vscode';
 import * as vscode from 'vscode';
 import ExtensionDeclaration from './extensionProvider/extensionDeclaration';
+import Configuration from '../configuration';
 
 
 export default class OrganizeExtensionProvider implements CodeActionProvider {
   public static commandId: string = 'haskell.organizeExtensions';
   private diagnosticCollection: vscode.DiagnosticCollection;
   private static diagnosticCode: string = "haskutil.unorganizedExtensions";
-
-  private static get shouldSplitExtensions(): boolean {
-    return OrganizeExtensionProvider.configuration.get("splitExtensions");
-  }
-
-  private static get shouldAlignExtensions(): boolean {
-    return OrganizeExtensionProvider.configuration.get("alignExtensions");
-  }
-
-  private static get shouldSortExtensions(): boolean {
-    return OrganizeExtensionProvider.configuration.get("sortExtensions");
-  }
-
-  private static get shouldOrganizeExtensionsOnSave(): boolean {
-    return OrganizeExtensionProvider.configuration.get("organiseExtensionOnSave");
-  }
-
-  private static get configuration(): WorkspaceConfiguration {
-    return vscode.workspace.getConfiguration("haskutil");
-  }
-
 
   public activate(subscriptions: Disposable[]) {
     const command = vscode.commands.registerCommand(OrganizeExtensionProvider.commandId, this.runCodeAction, this);
@@ -53,10 +33,10 @@ export default class OrganizeExtensionProvider implements CodeActionProvider {
     const aligned =
       extensions.length === 0 ||
       extensions.every(extension => extension.extensions.length === extensions[0].extensions.length);
-    unorganized = unorganized || OrganizeExtensionProvider.shouldAlignExtensions && !aligned;
+    unorganized = unorganized || Configuration.shouldAlignExtensions && !aligned;
 
     let pred = "";
-    if (OrganizeExtensionProvider.shouldSortExtensions) {
+    if (Configuration.shouldSortExtensions) {
       for (const extension of extensions) {
         const curr = extension.extensions;
         if (curr < pred) {
@@ -101,19 +81,19 @@ export default class OrganizeExtensionProvider implements CodeActionProvider {
   }
 
   private async runCodeAction(document: TextDocument) {
-    if (OrganizeExtensionProvider.shouldSplitExtensions) {
+    if (Configuration.shouldSplitExtensions) {
       await this.splitExtensions(document);
     }
-    if (OrganizeExtensionProvider.shouldAlignExtensions) {
+    if (Configuration.shouldAlignExtensions) {
       await this.alignExtensions(document);
     }
-    if (OrganizeExtensionProvider.shouldSortExtensions) {
+    if (Configuration.shouldSortExtensions) {
       await this.sortExtensions(document);
     }
   }
 
   private ensureOrganized(event: TextDocumentWillSaveEvent) {
-    if (OrganizeExtensionProvider.shouldOrganizeExtensionsOnSave) {
+    if (Configuration.shouldOrganizeExtensionsOnSave) {
       event.waitUntil(this.runCodeAction(event.document));
     }
   }

--- a/src/features/organizeImportProvider.ts
+++ b/src/features/organizeImportProvider.ts
@@ -74,8 +74,7 @@ export default class OrganizeImportProvider implements CodeActionProvider {
 
   public async provideCodeActions(document: TextDocument, range: Range, context: CodeActionContext, token: CancellationToken): Promise<CodeAction[]> {
     let codeActions = [];
-    const diagnostics = context.diagnostics.filter(d =>
-      range.contains(d.range) && d.code === OrganizeImportProvider.diagnosticCode);
+    const diagnostics = context.diagnostics.filter(d => d.code === OrganizeImportProvider.diagnosticCode);
     for (let diagnostic of diagnostics) {
       let title = "Organize imports";
       let codeAction = new CodeAction(title, CodeActionKind.QuickFix);

--- a/src/features/organizeImportProvider.ts
+++ b/src/features/organizeImportProvider.ts
@@ -7,7 +7,6 @@ import ImportDeclaration from './importProvider/importDeclaration';
 
 export default class OrganizeImportProvider implements CodeActionProvider {
   public static commandId: string = 'haskell.organizeImports';
-  private command: Disposable;
   private diagnosticCollection: vscode.DiagnosticCollection;
   private static diagnosticCode: string = "haskutil.unorganizedImports";
 
@@ -34,21 +33,16 @@ export default class OrganizeImportProvider implements CodeActionProvider {
 
 
   public activate(subscriptions: Disposable[]) {
-    this.command = vscode.commands.registerCommand(OrganizeImportProvider.commandId, this.runCodeAction, this);
-    subscriptions.push(this);
+    const command = vscode.commands.registerCommand(OrganizeImportProvider.commandId, this.runCodeAction, this);
+    subscriptions.push(command);
 
     this.diagnosticCollection = vscode.languages.createDiagnosticCollection();
+    subscriptions.push(this.diagnosticCollection);
     vscode.workspace.onDidOpenTextDocument(this.checkImports, this, subscriptions);
     vscode.workspace.onDidCloseTextDocument(doc => this.diagnosticCollection.delete(doc.uri), null, subscriptions);
     vscode.workspace.onDidSaveTextDocument(this.checkImports, this, subscriptions);
     vscode.workspace.onWillSaveTextDocument(this.ensureOrganized, this, subscriptions);
     vscode.workspace.textDocuments.filter(d => d.languageId === 'haskell').forEach(this.checkImports, this);
-  }
-
-  public dispose(): void {
-    this.diagnosticCollection.clear();
-    this.diagnosticCollection.dispose();
-    this.command.dispose();
   }
 
   private checkImports(document: TextDocument) {

--- a/src/features/organizeImportProvider.ts
+++ b/src/features/organizeImportProvider.ts
@@ -74,7 +74,9 @@ export default class OrganizeImportProvider implements CodeActionProvider {
 
   public async provideCodeActions(document: TextDocument, range: Range, context: CodeActionContext, token: CancellationToken): Promise<CodeAction[]> {
     let codeActions = [];
-    for (let diagnostic of context.diagnostics.filter(d => d.code === OrganizeImportProvider.diagnosticCode)) {
+    const diagnostics = context.diagnostics.filter(d =>
+      range.contains(d.range) && d.code === OrganizeImportProvider.diagnosticCode);
+    for (let diagnostic of diagnostics) {
       let title = "Organize imports";
       let codeAction = new CodeAction(title, CodeActionKind.QuickFix);
       codeAction.command = {

--- a/src/features/qualifiedImportProvider.ts
+++ b/src/features/qualifiedImportProvider.ts
@@ -13,7 +13,10 @@ export default class QualifiedImportProvider extends ImportProviderBase implemen
   public async provideCodeActions(document: TextDocument, range: Range, context: CodeActionContext, token: CancellationToken): Promise<any> {
     const pattern = /Not in scope:[^`]*[`‘]([^.]+)\.([^'’]+)['’]/;
     let codeActions = [];
-    for (let diagnostic of context.diagnostics.filter(d => d.severity === vscode.DiagnosticSeverity.Error)) {
+    const diagnostics = context.diagnostics.filter(d =>
+      range.contains(d.range) && d.severity === vscode.DiagnosticSeverity.Error
+    );
+    for (let diagnostic of diagnostics) {
       const match = pattern.exec(diagnostic.message);
       if (match === null) {
         continue;

--- a/src/features/qualifiedImportProvider.ts
+++ b/src/features/qualifiedImportProvider.ts
@@ -13,9 +13,7 @@ export default class QualifiedImportProvider extends ImportProviderBase implemen
   public async provideCodeActions(document: TextDocument, range: Range, context: CodeActionContext, token: CancellationToken): Promise<any> {
     const pattern = /Not in scope:[^`]*[`‘]([^.]+)\.([^'’]+)['’]/;
     let codeActions = [];
-    const diagnostics = context.diagnostics.filter(d =>
-      range.contains(d.range) && d.severity === vscode.DiagnosticSeverity.Error
-    );
+    const diagnostics = context.diagnostics.filter(d => d.severity === vscode.DiagnosticSeverity.Error);
     for (let diagnostic of diagnostics) {
       const match = pattern.exec(diagnostic.message);
       if (match === null) {

--- a/src/features/removeUnusedImportProvider.ts
+++ b/src/features/removeUnusedImportProvider.ts
@@ -8,21 +8,15 @@ import OrganizeImportProvider from './organizeImportProvider';
 
 export default class RemoveUnusedImportProvider implements CodeActionProvider {
   public static commandId: string = 'haskell.removeUnusedImports';
-  private command: Disposable;
   private diagnosticCollection: vscode.DiagnosticCollection;
   private static diagnosticCode: string = "haskutil.unusedImports";
 
   public activate(subscriptions: Disposable[]) {
-    this.command = vscode.commands.registerCommand(RemoveUnusedImportProvider.commandId, this.runCodeAction, this);
-    subscriptions.push(this);
+    const command = vscode.commands.registerCommand(RemoveUnusedImportProvider.commandId, this.runCodeAction, this);
+    subscriptions.push(command);
     this.diagnosticCollection = vscode.languages.createDiagnosticCollection();
+    subscriptions.push(this.diagnosticCollection);
     vscode.languages.onDidChangeDiagnostics(this.didChangeDiagnostics, this, subscriptions);
-  }
-
-  public dispose(): void {
-    this.diagnosticCollection.clear();
-    this.diagnosticCollection.dispose();
-    this.command.dispose();
   }
 
   private async didChangeDiagnostics(e: DiagnosticChangeEvent) {

--- a/src/features/removeUnusedImportProvider.ts
+++ b/src/features/removeUnusedImportProvider.ts
@@ -43,7 +43,10 @@ export default class RemoveUnusedImportProvider implements CodeActionProvider {
 
   public async provideCodeActions(document: TextDocument, range: Range, context: CodeActionContext, token: CancellationToken): Promise<CodeAction[]> {
     let codeActions = [];
-    for (let diagnostic of context.diagnostics.filter(d => d.code === RemoveUnusedImportProvider.diagnosticCode)) {
+    const diagnostics = context.diagnostics.filter(d =>
+      range.contains(d.range) && d.code === RemoveUnusedImportProvider.diagnosticCode
+    );
+    for (let diagnostic of diagnostics) {
       let title = "Remove unused imports";
       let codeAction = new CodeAction(title, CodeActionKind.QuickFix);
       codeAction.command = {

--- a/src/features/removeUnusedImportProvider.ts
+++ b/src/features/removeUnusedImportProvider.ts
@@ -1,9 +1,8 @@
-'use strict';
-
 import { CodeActionProvider, Disposable, TextDocument, Range, CodeActionContext, CancellationToken, CodeAction, WorkspaceEdit, CodeActionKind, Diagnostic, DiagnosticSeverity, DiagnosticChangeEvent, Uri } from 'vscode';
 import * as vscode from 'vscode';
 import ImportDeclaration from './importProvider/importDeclaration';
 import OrganizeImportProvider from './organizeImportProvider';
+import Configuration from '../configuration';
 
 
 export default class RemoveUnusedImportProvider implements CodeActionProvider {
@@ -75,7 +74,7 @@ export default class RemoveUnusedImportProvider implements CodeActionProvider {
         toBeDeleted.push(range);
       }
     }
-    if (OrganizeImportProvider.shouldAlignImports) {
+    if (Configuration.shouldAlignImports) {
       imports = OrganizeImportProvider.alignImports(imports);
     }
     for (const imp of imports) {

--- a/src/features/removeUnusedImportProvider.ts
+++ b/src/features/removeUnusedImportProvider.ts
@@ -43,9 +43,7 @@ export default class RemoveUnusedImportProvider implements CodeActionProvider {
 
   public async provideCodeActions(document: TextDocument, range: Range, context: CodeActionContext, token: CancellationToken): Promise<CodeAction[]> {
     let codeActions = [];
-    const diagnostics = context.diagnostics.filter(d =>
-      range.contains(d.range) && d.code === RemoveUnusedImportProvider.diagnosticCode
-    );
+    const diagnostics = context.diagnostics.filter(d => d.code === RemoveUnusedImportProvider.diagnosticCode);
     for (let diagnostic of diagnostics) {
       let title = "Remove unused imports";
       let codeAction = new CodeAction(title, CodeActionKind.QuickFix);

--- a/src/features/topLevelSignatureProvider.ts
+++ b/src/features/topLevelSignatureProvider.ts
@@ -15,7 +15,7 @@ export default class TopLevelSignatureProvider implements CodeActionProvider {
   public async provideCodeActions(document: TextDocument, range: Range, context: CodeActionContext, token: CancellationToken): Promise<any> {
     const pattern = /Top-level binding with no type signature:\s+([^]+)/;
     const codeActions = [];
-    for (const diagnostic of context.diagnostics) {
+    for (const diagnostic of context.diagnostics.filter(d => range.contains(d.range))) {
       const match = pattern.exec(diagnostic.message);
       if (match === null) {
         continue;

--- a/src/features/topLevelSignatureProvider.ts
+++ b/src/features/topLevelSignatureProvider.ts
@@ -6,15 +6,10 @@ import * as vscode from 'vscode';
 
 export default class TopLevelSignatureProvider implements CodeActionProvider {
   private static commandId: string = 'haskell.addTopLevelSignature';
-  private command: Disposable;
 
   public activate(subscriptions: Disposable[]) {
-    this.command = vscode.commands.registerCommand(TopLevelSignatureProvider.commandId, this.runCodeAction, this);
-    subscriptions.push(this);
-  }
-
-  public dispose(): void {
-    this.command.dispose();
+    const command = vscode.commands.registerCommand(TopLevelSignatureProvider.commandId, this.runCodeAction, this);
+    subscriptions.push(command);
   }
 
   public async provideCodeActions(document: TextDocument, range: Range, context: CodeActionContext, token: CancellationToken): Promise<any> {

--- a/src/features/topLevelSignatureProvider.ts
+++ b/src/features/topLevelSignatureProvider.ts
@@ -15,7 +15,7 @@ export default class TopLevelSignatureProvider implements CodeActionProvider {
   public async provideCodeActions(document: TextDocument, range: Range, context: CodeActionContext, token: CancellationToken): Promise<any> {
     const pattern = /Top-level binding with no type signature:\s+([^]+)/;
     const codeActions = [];
-    for (const diagnostic of context.diagnostics.filter(d => range.contains(d.range))) {
+    for (const diagnostic of context.diagnostics) {
       const match = pattern.exec(diagnostic.message);
       if (match === null) {
         continue;

--- a/src/features/typeWildcardProvider.ts
+++ b/src/features/typeWildcardProvider.ts
@@ -6,15 +6,10 @@ import * as vscode from 'vscode';
 
 export default class TypeWildcardProvider implements CodeActionProvider {
   private static commandId: string = 'haskell.fillTypeWildcard';
-  private command: Disposable;
 
   public activate(subscriptions: Disposable[]) {
-    this.command = vscode.commands.registerCommand(TypeWildcardProvider.commandId, this.runCodeAction, this);
-    subscriptions.push(this);
-  }
-
-  public dispose(): void {
-    this.command.dispose();
+    const command = vscode.commands.registerCommand(TypeWildcardProvider.commandId, this.runCodeAction, this);
+    subscriptions.push(command);
   }
 
   public async provideCodeActions(document: TextDocument, range: Range, context: CodeActionContext, token: CancellationToken): Promise<any> {

--- a/src/features/typeWildcardProvider.ts
+++ b/src/features/typeWildcardProvider.ts
@@ -16,7 +16,7 @@ export default class TypeWildcardProvider implements CodeActionProvider {
     const errorPattern = / Found type wildcard [`‘](.+?)['’]/;
     const fillPattern = /standing for [`‘](.+?)['’]/;
     const codeActions = [];
-    for (const diagnostic of context.diagnostics.filter(d => range.contains(d.range))) {
+    for (const diagnostic of context.diagnostics) {
       const match = errorPattern.exec(diagnostic.message);
       if (match === null) {
         continue;

--- a/src/features/typeWildcardProvider.ts
+++ b/src/features/typeWildcardProvider.ts
@@ -16,7 +16,7 @@ export default class TypeWildcardProvider implements CodeActionProvider {
     const errorPattern = / Found type wildcard [`‘](.+?)['’]/;
     const fillPattern = /standing for [`‘](.+?)['’]/;
     const codeActions = [];
-    for (const diagnostic of context.diagnostics) {
+    for (const diagnostic of context.diagnostics.filter(d => range.contains(d.range))) {
       const match = errorPattern.exec(diagnostic.message);
       if (match === null) {
         continue;

--- a/src/features/typedHoleProvider.ts
+++ b/src/features/typedHoleProvider.ts
@@ -6,15 +6,10 @@ import * as vscode from 'vscode';
 
 export default class TypedHoleProvider implements CodeActionProvider {
   private static commandId: string = 'haskell.fillTypeHoleSignature';
-  private command: Disposable;
 
   public activate(subscriptions: Disposable[]) {
-    this.command = vscode.commands.registerCommand(TypedHoleProvider.commandId, this.runCodeAction, this);
-    subscriptions.push(this);
-  }
-
-  public dispose(): void {
-    this.command.dispose();
+    const command = vscode.commands.registerCommand(TypedHoleProvider.commandId, this.runCodeAction, this);
+    subscriptions.push(command);
   }
 
   public async provideCodeActions(document: TextDocument, range: Range, context: CodeActionContext, token: CancellationToken): Promise<any> {

--- a/src/features/typedHoleProvider.ts
+++ b/src/features/typedHoleProvider.ts
@@ -16,7 +16,7 @@ export default class TypedHoleProvider implements CodeActionProvider {
     const errorPattern = / Found hole: ([^\s]+?) ::/;
     const fillPattern = /^\s+([^\s]+)\s::/gm;
     const codeActions = [];
-    for (const diagnostic of context.diagnostics.filter(d => range.contains(d.range))) {
+    for (const diagnostic of context.diagnostics) {
       const match = errorPattern.exec(diagnostic.message);
       if (match === null) {
         continue;

--- a/src/features/typedHoleProvider.ts
+++ b/src/features/typedHoleProvider.ts
@@ -16,7 +16,7 @@ export default class TypedHoleProvider implements CodeActionProvider {
     const errorPattern = / Found hole: ([^\s]+?) ::/;
     const fillPattern = /^\s+([^\s]+)\s::/gm;
     const codeActions = [];
-    for (const diagnostic of context.diagnostics) {
+    for (const diagnostic of context.diagnostics.filter(d => range.contains(d.range))) {
       const match = errorPattern.exec(diagnostic.message);
       if (match === null) {
         continue;

--- a/src/test/providers.test.ts
+++ b/src/test/providers.test.ts
@@ -22,7 +22,7 @@ suite("ExtensionProvider", function () {
   });  
 
   test("Remove unused imports", async () => {
-    await runQuickfixTest('UnusedImportProvider.hs', 1);
+    await runQuickfixTest('UnusedImportProvider.hs', 3);
   });
   
   test("Add missing extension", async () => {

--- a/src/test/providers.test.ts
+++ b/src/test/providers.test.ts
@@ -26,7 +26,7 @@ suite("ExtensionProvider", function () {
   });
   
   test("Add missing extension", async () => {
-    await runQuickfixTest('ExtensionProvider.hs', 1);
+    await runQuickfixTest('ExtensionProvider.hs', 2);
   });
 
   test("Organize extensions", async () => {

--- a/src/test/providers.test.ts
+++ b/src/test/providers.test.ts
@@ -1,4 +1,5 @@
-import { runQuickfixTest, outputGHCiLog } from './utils';
+import * as vscode from 'vscode';
+import { runQuickfixTest } from './utils';
 
 
 suite("ExtensionProvider", function () {

--- a/src/test/providers.test.ts
+++ b/src/test/providers.test.ts
@@ -2,7 +2,12 @@ import * as vscode from 'vscode';
 import { runQuickfixTest } from './utils';
 
 
-suite("ExtensionProvider", function () {
+suite("Features", function () {
+  setup(async () => {
+    const config = vscode.workspace.getConfiguration('hoogle-vscode');
+    await config.update('verbose', true);
+  });
+
   test("Add missing import", async () => {
     await runQuickfixTest('ImportProvider.hs', 3,
       'Add: "import Data.Maybe"',

--- a/src/test/providers.test.ts
+++ b/src/test/providers.test.ts
@@ -2,12 +2,11 @@ import * as vscode from 'vscode';
 import { runQuickfixTest } from './utils';
 
 
-suite("Features", function () {
-  setup(async () => {
-    const config = vscode.workspace.getConfiguration('hoogle-vscode');
-    await config.update('verbose', true);
-  });
-
+suite("ExtensionProvider", function () {
+  test("Organize imports", async () => {
+    await runQuickfixTest('OrganizeImportProvider.hs', 1);
+  });  
+  
   test("Add missing import", async () => {
     await runQuickfixTest('ImportProvider.hs', 3,
       'Add: "import Data.Maybe"',
@@ -21,10 +20,6 @@ suite("Features", function () {
       'Add: "import qualified Data.ByteString as BS"'
     );
   });
-
-  test("Organize imports", async () => {
-    await runQuickfixTest('OrganizeImportProvider.hs', 1);
-  });  
 
   test("Remove unused imports", async () => {
     await runQuickfixTest('UnusedImportProvider.hs', 3);

--- a/src/test/providers.test.ts
+++ b/src/test/providers.test.ts
@@ -1,12 +1,11 @@
 import * as vscode from 'vscode';
-import { runQuickfixTest } from './utils';
+import { runQuickfixTest, warmup } from './utils';
 
 
 suite("ExtensionProvider", function () {
-  test("Organize imports", async () => {
-    await runQuickfixTest('OrganizeImportProvider.hs', 1);
-  });  
-  
+
+  suiteSetup(warmup);
+
   test("Add missing import", async () => {
     await runQuickfixTest('ImportProvider.hs', 3,
       'Add: "import Data.Maybe"',
@@ -20,6 +19,10 @@ suite("ExtensionProvider", function () {
       'Add: "import qualified Data.ByteString as BS"'
     );
   });
+
+  test("Organize imports", async () => {
+    await runQuickfixTest('OrganizeImportProvider.hs', 1);
+  });  
 
   test("Remove unused imports", async () => {
     await runQuickfixTest('UnusedImportProvider.hs', 3);

--- a/src/test/runTest.ts
+++ b/src/test/runTest.ts
@@ -33,7 +33,7 @@ async function main() {
     }
     
     // Download VS Code, unzip it and run the integration test
-    await runTests({
+    const result = await runTests({
       vscodeExecutablePath,
       extensionDevelopmentPath,
       extensionTestsPath,
@@ -48,10 +48,11 @@ async function main() {
         '--disable-telemetry',
       ]
     });
+    return result;
   } catch (err) {
     console.error(err);
     console.error('Failed to run tests');
-    process.exit(1);
+    return 1;
   }
 }
 

--- a/src/test/runTest.ts
+++ b/src/test/runTest.ts
@@ -17,8 +17,6 @@ async function main() {
     // Passed to --extensionTestsPath
     const extensionTestsPath = __dirname;
 
-    const inputPath = path.resolve(extensionDevelopmentPath, 'input')
-
     const vscodeExecutablePath = await downloadAndUnzipVSCode();
     const cliPath = resolveCliPathFromVSCodeExecutablePath(vscodeExecutablePath);
 
@@ -40,7 +38,6 @@ async function main() {
       extensionDevelopmentPath,
       extensionTestsPath,
       launchArgs: [
-        inputPath,
         '--new-window',
         '--disable-gpu',
         '--disable-updates',

--- a/src/test/runTest.ts
+++ b/src/test/runTest.ts
@@ -17,6 +17,8 @@ async function main() {
     // Passed to --extensionTestsPath
     const extensionTestsPath = __dirname;
 
+    const inputPath = path.resolve(extensionDevelopmentPath, 'input')
+
     const vscodeExecutablePath = await downloadAndUnzipVSCode();
     const cliPath = resolveCliPathFromVSCodeExecutablePath(vscodeExecutablePath);
 
@@ -38,6 +40,7 @@ async function main() {
       extensionDevelopmentPath,
       extensionTestsPath,
       launchArgs: [
+        inputPath,
         '--new-window',
         '--disable-gpu',
         '--disable-updates',

--- a/src/test/utils.ts
+++ b/src/test/utils.ts
@@ -4,6 +4,7 @@ import * as path from 'path';
 import * as util from 'util';
 import { Range, Position, CodeAction, TextDocument, Disposable } from 'vscode';
 import { assert } from 'chai';
+import { promisify } from 'util';
 
 
 export async function runQuickfixTest(file: string, diagnosticCount: number, ...titles: string[]) {
@@ -28,7 +29,18 @@ export async function runQuickfixTest(file: string, diagnosticCount: number, ...
 
   const expected = await util.promisify(fs.readFile)(after, { encoding: 'utf8' });
   assert.strictEqual(doc.getText(), expected);
-  vscode.commands.executeCommand('workbench.action.closeActiveEditor');
+  await vscode.commands.executeCommand('workbench.action.closeActiveEditor');
+}
+
+export async function warmup() {
+  const before = path.join(__dirname, '../../input/Welcome.hs');
+  const doc = await didChangeDiagnostics(before, 3, async () => {
+    const doc = await vscode.workspace.openTextDocument(before);
+    await vscode.window.showTextDocument(doc);
+    return doc;
+  });
+  await getQuickFixes(doc);
+  await vscode.commands.executeCommand('workbench.action.closeActiveEditor');
 }
 
 export async function getQuickFixes(doc : TextDocument): Promise<CodeAction[]> {

--- a/src/test/utils.ts
+++ b/src/test/utils.ts
@@ -15,16 +15,16 @@ export async function runQuickfixTest(file: string, diagnosticCount: number, ...
     return doc;
   });
   const diagnostics = vscode.languages.getDiagnostics(doc.uri);
-  const quickFixes = await getQuickFixes(doc);
-  const applicableQuickFixes = quickFixes.filter(qf => !titles.length || titles.includes(qf.title));
-  assert.isNotEmpty(applicableQuickFixes, `
+  const available = await getQuickFixes(doc);
+  const applicable = available.filter(qf => !titles.length || titles.includes(qf.title));
+  assert.isNotEmpty(applicable, `
     Could not find any applicable QuickFixes.
-    Available: '${quickFixes.map(qf => qf.title).join(', ')}'
+    Available: '${available.map(qf => qf.title).join(', ')}'
     Requested: '${titles.join(', ')}'
     Diagnostics: '${diagnostics.map(d => d.message).join('\n')}'
   `);
 
-  await runQuickFixes(applicableQuickFixes);
+  await runQuickFixes(applicable);
 
   const expected = await util.promisify(fs.readFile)(after, { encoding: 'utf8' });
   assert.strictEqual(doc.getText(), expected);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "target": "es6",
     "outDir": "out",
     "lib": [
-      "es6"
+      "es2019"
     ],
     "sourceMap": true,
     "rootDir": "src",


### PR DESCRIPTION
- Added
  - `haskutil.organiseImportsOnInsert` configuration option
  - More test coverage
- Fixed
  - Run multiple Hoogle requests in parallel
  - Send already calculated coverage to coveralls.io 