### PR TITLE
Fix extension publishing

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,7 +1,7 @@
-.vscode/**
-.vscode-test/**
-.nyc_output
+.github/**
 .gitignore
+.nyc_output
+.vscode/**
 input
 out/test
 out/coverage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change Log
 All notable changes to the "Haskutil" extension will be documented in this file.
 
+## [0.10.3] - 2020-09-25
+### Fixed
+* Fix extension publishing via `npm run publish`
+
 ## [0.10.2] - 2020-09-22
 ### Added
 * Github actions build: matrix builds on multiple platforms and publishing to Marketplace on version tag push

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "haskutil",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "haskutil",
   "displayName": "Haskutil",
   "description": "'QuickFix' actions for Haskell editor",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "publisher": "Edka",
   "repository": {
     "url": "https://github.com/EduardSergeev/vscode-haskutil"
@@ -188,6 +188,7 @@
     "coverage": "nyc npm test",
     "prepackage": "npm run compile",
     "package": "vsce package",
+    "preupload": "npm run package",
     "upload": "vsce publish"
   },
   "nyc": {


### PR DESCRIPTION
Add missing `out` directory to the package created via `npm run publish`