### PR TITLE
Qualified import suggestion fixes

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -24,7 +24,7 @@ jobs:
           - 9.0.2
           - 9.4.5
         env:
-          - { CODE_VERSION: 1.38.0, DISPLAY: ':99.0' }
+          - { CODE_VERSION: 1.48.0, DISPLAY: ':99.0' }
           - { CODE_VERSION: 'stable', DISPLAY: ':99.0' }
     runs-on: ${{ matrix.os }}
     env: ${{ matrix.env }}

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -24,7 +24,7 @@ jobs:
           - 9.0.2
           - 9.4.5
         env:
-          - { CODE_VERSION: 1.48.0, DISPLAY: ':99.0' }
+          - { CODE_VERSION: 1.66.2, DISPLAY: ':99.0' }
           - { CODE_VERSION: 'stable', DISPLAY: ':99.0' }
     runs-on: ${{ matrix.os }}
     env: ${{ matrix.env }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,27 @@
 # Change Log
 All notable changes to the "Haskutil" extension will be documented in this file.
 
+## [0.10.8] - 2023-08-21
+### Fixed
+* `QualifiedImportProvider`:  
+  - Suppress `Add: "import qualified ... as undefined"` suggestions
+  - Avoid annecessary alias in qualified import: fixes [#48](https://github.com/EduardSergeev/vscode-haskutil/issues/48)
+* `certificate has expired` error in tests:  
+  Switch to VSCode version `1.66.2` which does not have this problem
+### Changed
+* Oldest supported VSCode version is now `1.48.0`
+
 ## [0.10.7] - 2023-08-20
 ### Fixed
-* `RemoveUnusedImportProvider` on GHC > `9.0.2`:
+* `RemoveUnusedImportProvider` on GHC > `9.0.2`:  
   Fix `Cannot read properties of undefined (reading 'removeElement')` exception
-* `TypeWildcardProvider`:
-  Handle various error message formats:
+* `TypeWildcardProvider`:  
+  Handle various error message formats:  
   - old from GHC <= `9.0.2`
   - new from GHC > `9.0.2`
-* `QualifiedImportProvider` on GHC > `9.0.2`:
+* `QualifiedImportProvider` on GHC > `9.0.2`:  
   Newer GHC uses a different error message format
-* `ExtensionProvider`:
+* `ExtensionProvider`:  
   - Do not create duplicated QuickFix actions
   - Switch to `DataKinds` extension in test
 * Update all dependencies to the latest versions

--- a/input/after/QualifiedImportProvider.hs
+++ b/input/after/QualifiedImportProvider.hs
@@ -1,5 +1,9 @@
 import qualified Data.ByteString as BS
 import           Data.Word
+import qualified Numeric
 
 foo xs =
   BS.pack xs
+
+bar i =
+  Numeric.showInt i

--- a/input/before/QualifiedImportProvider.hs
+++ b/input/before/QualifiedImportProvider.hs
@@ -2,3 +2,6 @@ import Data.Word
 
 foo xs =
   BS.pack xs
+
+bar i =
+  Numeric.showInt i

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "haskutil",
-  "version": "0.10.7",
+  "version": "0.10.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "haskutil",
-      "version": "0.10.7",
+      "version": "0.10.8",
       "license": "MIT",
       "devDependencies": {
         "@istanbuljs/nyc-config-typescript": "1.0.2",
         "@types/chai": "4.3.5",
         "@types/mocha": "10.0.1",
         "@types/node": "20.5.0",
-        "@types/vscode": "1.38.0",
+        "@types/vscode": "1.48.0",
         "@vscode/test-electron": "2.3.4",
         "@vscode/vsce": "2.20.1",
         "chai": "4.3.7",
@@ -25,7 +25,7 @@
         "typescript": "4.9.5"
       },
       "engines": {
-        "vscode": "^1.38.0"
+        "vscode": "^1.48.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -598,9 +598,9 @@
       "dev": true
     },
     "node_modules/@types/vscode": {
-      "version": "1.38.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.38.0.tgz",
-      "integrity": "sha512-aGo8LQ4J1YF0T9ORuCO+bhQ5sGR1MXa7VOyOdEP685se3wyQWYUExcdiDi6rvaK61KUwfzzA19JRLDrUbDl7BQ==",
+      "version": "1.48.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.48.0.tgz",
+      "integrity": "sha512-sZJKzsJz1gSoFXcOJWw3fnKl2sseUgZmvB4AJZS+Fea+bC/jfGPVhmFL/FfQHld/TKtukVONsmoD3Pkyx9iadg==",
       "dev": true
     },
     "node_modules/@vscode/test-electron": {

--- a/package.json
+++ b/package.json
@@ -2,13 +2,13 @@
   "name": "haskutil",
   "displayName": "Haskutil",
   "description": "'QuickFix' actions for Haskell editor",
-  "version": "0.10.7",
+  "version": "0.10.8",
   "publisher": "Edka",
   "repository": {
     "url": "https://github.com/EduardSergeev/vscode-haskutil"
   },
   "engines": {
-    "vscode": "^1.38.0"
+    "vscode": "^1.48.0"
   },
   "categories": [
     "Other"
@@ -217,7 +217,7 @@
     "@types/chai": "4.3.5",
     "@types/mocha": "10.0.1",
     "@types/node": "20.5.0",
-    "@types/vscode": "1.38.0",
+    "@types/vscode": "1.48.0",
     "@vscode/vsce": "2.20.1",
     "@vscode/test-electron": "2.3.4",
     "chai": "4.3.7",

--- a/src/features/importProvider/importProviderBase.ts
+++ b/src/features/importProvider/importProviderBase.ts
@@ -57,7 +57,7 @@ export default class ImportProviderBase {
     return result;
   }
 
-  private async runCodeAction(document: TextDocument, moduleName: string, options: { alias?: string, elementName?: string } = {}): Promise<void> {
+  private async runCodeAction(document: TextDocument, moduleName: string, options: { qualified?: Boolean, alias?: string, elementName?: string } = {}): Promise<void> {
     function afterMatch(offset) {
       const position = document.positionAt(offset);
       return document.offsetAt(position.with(position.line + 1, 0));
@@ -97,9 +97,11 @@ export default class ImportProviderBase {
         position = afterMatch(importInfo.offset + importInfo.length);
       }
       const importDeclaration = new ImportDeclaration(moduleName);
-      if (options.alias) {
+      if (options.qualified) {
         importDeclaration.qualified = " qualified ";
-        importDeclaration.alias = options.alias;
+        if (options.alias) {
+          importDeclaration.alias = options.alias;
+        }
       }
       if (options.elementName) {
         importDeclaration.addImportElement(options.elementName);

--- a/src/features/qualifiedImportProvider.ts
+++ b/src/features/qualifiedImportProvider.ts
@@ -36,7 +36,7 @@ export default class QualifiedImportProvider extends ImportProviderBase implemen
         }
 
         const results = await this.search(name);
-        codeActions = codeActions.concat(this.addImportForVariable(document, ` as ${alias}`, results));
+        codeActions = codeActions.concat(this.addImportForVariable(document, alias, results));
         codeActions.forEach(action => {
           action.diagnostics = [diagnostic];
         });
@@ -48,7 +48,7 @@ export default class QualifiedImportProvider extends ImportProviderBase implemen
   private addImportForVariable(document: TextDocument, alias: string, searchResults: SearchResult[]): CodeAction[] {
     const codeActions = [];
     for (const result of searchResults) {
-      const title = `Add: "import qualified ${result.module}${alias}"`;
+      const title = `Add: "import qualified ${result.module}${result.module !== alias ? ` as ${alias}` : ''}"`;
       const codeAction = new CodeAction(title, CodeActionKind.QuickFix);
       codeAction.command = {
         title: title,
@@ -57,7 +57,8 @@ export default class QualifiedImportProvider extends ImportProviderBase implemen
           document,
           result.module,
           {
-            alias: alias
+            qualified: true,
+            alias: result.module !== alias ? ` as ${alias}` : null
           }
         ]
       };

--- a/src/features/qualifiedImportProvider.ts
+++ b/src/features/qualifiedImportProvider.ts
@@ -30,6 +30,8 @@ export default class QualifiedImportProvider extends ImportProviderBase implemen
           const expressionMatch = /(\S+)\.(\S+)/.exec(document.getText(diagnostic.range));
           if (expressionMatch) {
             alias = expressionMatch[1];
+          } else {
+            continue;
           }
         }
 

--- a/src/test/providers.test.ts
+++ b/src/test/providers.test.ts
@@ -25,8 +25,9 @@ suite('', () => {
   });
 
   test('Add missing import qualified', () => {
-    return runQuickfixTest('QualifiedImportProvider.hs', [DiagnosticSeverity.Error, 1],
-      'Add: "import qualified Data.ByteString as BS"'
+    return runQuickfixTest('QualifiedImportProvider.hs', [DiagnosticSeverity.Error, 2],
+      'Add: "import qualified Data.ByteString as BS"',
+      'Add: "import qualified Numeric"'
     );
   });
 

--- a/src/test/runTest.ts
+++ b/src/test/runTest.ts
@@ -25,7 +25,6 @@ async function main(): Promise<number> {
     const dependencies = [
       'jcanero.hoogle-vscode',
       'dramforever.vscode-ghc-simple',
-      // 'bin/vscode-ghc-simple-0.1.23.vsix',
     ];
 
     const extensionsDir = path.resolve(path.dirname(cliPath), '..', 'extensions');
@@ -37,7 +36,7 @@ async function main(): Promise<number> {
         stdio: 'inherit'
       });
     }
-    
+
     // Download VS Code, unzip it and run the integration test
     return await runTests({
       vscodeExecutablePath,


### PR DESCRIPTION
- Fix QualifiedImportProvider:  
  - Suppress invalid `Add: "import qualified ... as undefined"` QuickFix suggestions
  - Avoid annecessary alias in qualified import:  
    Add `import qualified Numeric` instead of `import qualified Numeric as Numeric` for `Numeric.showInt`
    This fixes #48
- Fix `certificate has expired` error in tests:  
  In (old VSCode) tests switch to VSCode version `1.66.2` which does not have this problem
- Bump oldest supported VSCode version to `1.48.0`