### PR TITLE
Optional dependent extension check

### DIFF
--- a/.github/workflows/branch.yml
+++ b/.github/workflows/branch.yml
@@ -2,13 +2,11 @@ name: branch
 
 on:
   push:
-    branches-ignore:
-      - master
 
 jobs:
   build:
     runs-on: ubuntu-latest
-    env: { CODE_VERSION: 'stable', DISPLAY: ':99.0', GHC: 9.4.5 }
+    env: { CODE_VERSION: 'stable', DISPLAY: ':99.0' }
     steps:
     - uses: actions/checkout@v3
 
@@ -17,11 +15,8 @@ jobs:
       with:
         node-version: 20
 
-    - name: Set up GHC ${{ env.GHC }} environment
-      run: |
-        echo "resolver: ghc-${{ env.GHC }}" > stack.yaml
-        echo "packages: []" >> stack.yaml
-        stack setup
+    - name: Set up GHC environment
+      run: stack setup
   
     - run: npm install
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Change Log
 All notable changes to the "Haskutil" extension will be documented in this file.
 
+## [0.11.0] - 2023-08-26
+### Added
+* `haskutil.checkDiagnosticsExtension` configuration option:
+  Check if any of recommended VSCode extensions which generate Haskell diagnostics is installed
+  Optional, default is `true`
+
 ## [0.10.8] - 2023-08-21
 ### Fixed
 * `QualifiedImportProvider`:  

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "haskutil",
   "displayName": "Haskutil",
   "description": "'QuickFix' actions for Haskell editor",
-  "version": "0.10.8",
+  "version": "0.11.0",
   "publisher": "Edka",
   "repository": {
     "url": "https://github.com/EduardSergeev/vscode-haskutil"
@@ -169,6 +169,11 @@
             "TypeApplications",
             "ViewPatterns"
           ]
+        },
+        "haskutil.checkDiagnosticsExtension": {
+          "type": "boolean",
+          "description": "Check if any of recommended VSCode extensions which generate Haskell diagnostics is installed",
+          "default": true
         }
       }
     }

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -14,6 +14,7 @@ const alignImportsSection = "alignImports";
 const alwaysPadImportsSection = "alwaysPadImports";
 const sortImportsSection = "sortImports";
 const organizeImportsOnSaveSection = "organiseImportsOnSave";
+const checkDiagnosticsExtensionSection = "checkDiagnosticsExtension";
 
 function root(): WorkspaceConfiguration {
   return vscode.workspace.getConfiguration(rootSection);
@@ -24,7 +25,8 @@ function get<T>(section: string): T {
 }
 
 
-export default class Configuration {  
+export default class Configuration {
+  public static rootSection = rootSection;
   public static organiseImportsOnInsertSection = organiseImportsOnInsertSection;
   public static organiseExtensionOnInsertSection = organiseExtensionOnInsertSection;
   public static supportedExtensionsSection = supportedExtensionsSection;
@@ -36,6 +38,7 @@ export default class Configuration {
   public static alwaysPadImportsSection = alwaysPadImportsSection;
   public static sortImportsSection = sortImportsSection;
   public static organizeImportsOnSaveSection = organizeImportsOnSaveSection;
+  public static checkDiagnosticsExtensionSection = checkDiagnosticsExtensionSection;
 
   public static get root(): WorkspaceConfiguration {
     return root();
@@ -83,5 +86,9 @@ export default class Configuration {
 
   public static get shouldOrganizeImportsOnSave(): boolean {
     return get(organizeImportsOnSaveSection);
+  } 
+
+  public static get checkDiagnosticsExtension(): boolean {
+    return get(checkDiagnosticsExtensionSection);
   } 
 }


### PR DESCRIPTION
- Add new configuration option: `haskutil.checkDiagnosticsExtension`:
  When set to `true` (by default):  
  1. Run the current check that any of the recommended extension which generates Haskell diagnostic is indeed installed
  2. Skip the check if `haskutil.checkDiagnosticsExtension` is set to `false`
  Use this setting to avoid `Haskutil` warning window on extension start up in case you are using diagnostics extension which is not listed among [recommended extensions](https://github.com/EduardSergeev/vscode-haskutil#requirements)  
  Add a link to `haskutil.checkDiagnosticsExtension` setting to the "Missing dependency" warning message popup so a user can disable this check in case 3rd-party Haskell diagnostics extension is used