### PR TITLE
Various fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 # Change Log
 All notable changes to the "Haskutil" extension will be documented in this file.
 
+## [0.11.2] - 2023-08-26
+### Fixed
+* `OrganizeExtensionProvider`:  
+  Make sure all `LANGUAGE` extension are aligning using minimal padding  
+  Fixes [#41](https://github.com/EduardSergeev/vscode-haskutil/issues/41)
+- `ImportProvider`:  
+  Suggest adding class or data type with `(..)`, i.e. with all defined constructors/members  
+  Fixes [#44](https://github.com/EduardSergeev/vscode-haskutil/issues/41)
+
 ## [0.11.0] - 2023-08-26
 ### Added
 * `haskutil.checkDiagnosticsExtension` configuration option:  

--- a/input/after/ImportProviderConstructor.hs
+++ b/input/after/ImportProviderConstructor.hs
@@ -1,0 +1,4 @@
+import Data.Proxy (Proxy(..))
+
+proxy :: Proxy Bool
+proxy = Proxy

--- a/input/before/ImportProviderConstructor.hs
+++ b/input/before/ImportProviderConstructor.hs
@@ -1,0 +1,3 @@
+
+proxy :: Proxy Bool
+proxy = Proxy

--- a/input/before/OrganizeExtensionProvider.hs
+++ b/input/before/OrganizeExtensionProvider.hs
@@ -4,7 +4,7 @@
 
 {-# LANGUAGE MultiParamTypeClasses,
   FlexibleContexts, FlexibleInstances #-}
-{-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE DeriveFunctor               #-}
 
 module Main where
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "haskutil",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "haskutil",
-      "version": "0.11.1",
+      "version": "0.11.2",
       "license": "MIT",
       "devDependencies": {
         "@istanbuljs/nyc-config-typescript": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "haskutil",
   "displayName": "Haskutil",
   "description": "'QuickFix' actions for Haskell editor",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "publisher": "Edka",
   "repository": {
     "url": "https://github.com/EduardSergeev/vscode-haskutil"

--- a/src/features/importProvider.ts
+++ b/src/features/importProvider.ts
@@ -26,7 +26,7 @@ export default class ImportProvider extends ImportProviderBase implements CodeAc
   }
 
   private addImportForVariable(document: TextDocument, diagnostic: Diagnostic, variableName: string, searchResults: SearchResult[]): CodeAction[] {
-    const codeActions = [];
+    const codeActions = new Map<string, CodeAction>();
     for (const result of searchResults) {
       let title = `Add: "import ${result.module}"`;
       let codeAction = new CodeAction(title, CodeActionKind.QuickFix);
@@ -39,9 +39,10 @@ export default class ImportProvider extends ImportProviderBase implements CodeAc
         ],
       };
       codeAction.diagnostics = [diagnostic];
-      codeActions.push(codeAction);
+      codeActions.set(title, codeAction);
 
-      title = `Add: "import ${result.module} (${variableName})"`;
+      const element = variableName[0] === variableName[0].toUpperCase() ? `${variableName}(..)` : variableName;
+      title = `Add: "import ${result.module} (${element})"`;
       codeAction = new CodeAction(title, CodeActionKind.QuickFix);
       codeAction.command = {
         title: title,
@@ -50,13 +51,13 @@ export default class ImportProvider extends ImportProviderBase implements CodeAc
           document,
           result.module,
           {
-            elementName: variableName
+            elementName: element
           }
         ]
       };
       codeAction.diagnostics = [diagnostic];
-      codeActions.push(codeAction);
+      codeActions.set(title, codeAction);
     }
-    return codeActions;
+    return [...codeActions.values()];
   }
 }

--- a/src/features/qualifiedImportProvider.ts
+++ b/src/features/qualifiedImportProvider.ts
@@ -46,7 +46,7 @@ export default class QualifiedImportProvider extends ImportProviderBase implemen
   }
 
   private addImportForVariable(document: TextDocument, alias: string, searchResults: SearchResult[]): CodeAction[] {
-    const codeActions = [];
+    const codeActions = new Map<string, CodeAction>();
     for (const result of searchResults) {
       const title = `Add: "import qualified ${result.module}${result.module !== alias ? ` as ${alias}` : ''}"`;
       const codeAction = new CodeAction(title, CodeActionKind.QuickFix);
@@ -62,8 +62,8 @@ export default class QualifiedImportProvider extends ImportProviderBase implemen
           }
         ]
       };
-      codeActions.push(codeAction);
+      codeActions.set(title, codeAction);
     }
-    return codeActions;
+    return [...codeActions.values()];
   }
 }

--- a/src/test/providers.test.ts
+++ b/src/test/providers.test.ts
@@ -31,6 +31,12 @@ suite('', () => {
     );
   });
 
+  test('Add missing constructor import', () => {
+    return runQuickfixTest('ImportProviderConstructor.hs', [DiagnosticSeverity.Error, 1],
+      'Add: "import Data.Proxy (Proxy(..))"'
+    );
+  });
+
   test('Organize imports', () => {
     return runQuickfixTest('OrganizeImportProvider.hs', 0);
   });  


### PR DESCRIPTION
- Fix: `OrganizeExtensionProvider`:
  Make sure all `LANGUAGE` extension are aligning using minimal padding
  Fixes #41
- Fix: `ImportProvider`:
  When class or data type is not in scope suggest adding it with `(..)` qualified, i.e. with all defined constructors/members
  E.g. suggest `Add: "import Data.Proxy (Proxy(..))"` instead of `Add: "import Data.Proxy (Proxy)"  
  Fixes #44