### PR TITLE
Various fixes

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -49,8 +49,8 @@ jobs:
       with:
         run: npm test
 
-    - name: Add GHC extension output (on failure on Linux)
-      if: failure() && runner.os == 'Linux'
+    - name: Add GHC extension output (on failure on Linux or MacOS)
+      if: failure() && runner.os != 'Windows'
       run: find .vscode-test/udd/logs -name *GHC* -exec cat {} \;
 
     - name: Add GHC extension output (on failure on Windows)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 # Change Log
 All notable changes to the "Haskutil" extension will be documented in this file.
 
+## [0.11.4] - 2023-08-27
+### Fixed
+* `OrganizeExtensionProvider`: false positive of `Extension are unorganised`
+  Aligned extension were incorrectly detected as being not aligned
+* `ImportProvider`: `Organize imports` behaviour on Windows
+  Fix invalid parsing of imports in file with `\r\n` (Windows) line ending
+  As a result applying `Organize imports` would previously lead to corrupted imports
+* Fail CI build in case of test failure:
+  Previously build would still be green even if some of the test wer failing
+
 ## [0.11.3] - 2023-08-26
 ### Fixed
 * `ImportProvider`:  

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "haskutil",
-  "version": "0.11.3",
+  "version": "0.11.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "haskutil",
-      "version": "0.11.3",
+      "version": "0.11.4",
       "license": "MIT",
       "devDependencies": {
         "@istanbuljs/nyc-config-typescript": "1.0.2",
@@ -16,7 +16,7 @@
         "@types/vscode": "1.48.0",
         "@vscode/test-electron": "2.3.4",
         "@vscode/vsce": "2.20.1",
-        "chai": "4.3.7",
+        "chai": "4.3.8",
         "mocha": "10.2.0",
         "nyc": "15.1.0",
         "source-map-support": "0.5.21",
@@ -1029,9 +1029,9 @@
       ]
     },
     "node_modules/chai": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.7.tgz",
-      "integrity": "sha512-HLnAzZ2iupm25PlN0xFreAlBA5zaBSv3og0DdeGA4Ar6h6rJ3A0rolRUKJhSF2V10GZKDgWF/VmAEsNWjCRB+A==",
+      "version": "4.3.8",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.8.tgz",
+      "integrity": "sha512-vX4YvVVtxlfSZ2VecZgFUTU5qPCYsobVI2O9FmwEXBhDigYGQA6jRXCycIs1yJnnWbZ6/+a2zNIF5DfVCcJBFQ==",
       "dev": true,
       "dependencies": {
         "assertion-error": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "haskutil",
   "displayName": "Haskutil",
   "description": "'QuickFix' actions for Haskell editor",
-  "version": "0.11.3",
+  "version": "0.11.4",
   "publisher": "Edka",
   "repository": {
     "url": "https://github.com/EduardSergeev/vscode-haskutil"
@@ -225,7 +225,7 @@
     "@types/vscode": "1.48.0",
     "@vscode/vsce": "2.20.1",
     "@vscode/test-electron": "2.3.4",
-    "chai": "4.3.7",
+    "chai": "4.3.8",
     "mocha": "10.2.0",
     "nyc": "15.1.0",
     "source-map-support": "0.5.21",

--- a/src/features/importProvider/importDeclaration.ts
+++ b/src/features/importProvider/importDeclaration.ts
@@ -89,7 +89,7 @@ export default class ImportDeclaration {
   }
 
   public static getImports(text: string): ImportDeclaration[] {
-    const importPattern = /^import((?:\s+qualified\s+)|\s+)(\S+)(\s+as\s+(\S+))?(\s*?\(((?:(?:\(.*?\))|.|\n)*?)\))?(\s+hiding\s+\(((?:(?:\(.*?\))|.|\n)*?)\))?/gm;
+    const importPattern = /^import((?:\s+qualified\s+)|\s+)(\S+)(\s+as\s+(\S+))?(\s*?\(((?:(?:\(.*?\))|.|\r?\n)*?)\))?(\s+hiding\s+\(((?:(?:\(.*?\))|.|\r?\n)*?)\))?/gm;
     const imports = [];
     for (let match; match = importPattern.exec(text);) {
       imports.push(new ImportDeclaration(

--- a/src/features/organizeExtensionProvider.ts
+++ b/src/features/organizeExtensionProvider.ts
@@ -33,7 +33,7 @@ export default class OrganizeExtensionProvider implements CodeActionProvider {
     const aligned =
       extensions.length === 0 ||
       extensions.every(extension => extension.extensions.length === extensions[0].extensions.length) &&
-      Math.max(...extensions.map(extension => extension.extensions.trimEnd().length)) === extensions[0].extensions.length;
+      Math.max(...extensions.map(extension => extension.extensions.trimEnd().length + 1)) === extensions[0].extensions.length;
     unorganized = unorganized || Configuration.shouldAlignExtensions && !aligned;
 
     let pred = "";

--- a/src/test/runTest.ts
+++ b/src/test/runTest.ts
@@ -37,6 +37,9 @@ async function main(): Promise<number> {
       });
     }
 
+    // This is required for Mocha tests to report non-zero exit code in case of test failure
+    process.removeAllListeners('exit');
+
     // Download VS Code, unzip it and run the integration test
     return await runTests({
       vscodeExecutablePath,
@@ -62,7 +65,7 @@ async function main(): Promise<number> {
   } catch (err) {
     console.error(err);
     console.error('Failed to run tests');
-    return 1;
+    process.exit(1);
   }
 }
 


### PR DESCRIPTION
- Fix:
  - `OrganizeExtensionProvider`: false positive of `Extension are unorganised`
    Aligned extension were incorrectly detected as being not aligned
  - `ImportProvider`: `Organize imports` behaviour on Windows
    Fix invalid parsing of imports in file with `\r\n` (Windows) line ending
    As a result applying `Organize imports` would previously lead to corrupted imports
  - Fail CI build in case of test failure:
    Previously build would still be green even if some of the test wer failing