### PR TITLE
Configurable list of supported extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Change Log
 All notable changes to the "Haskutil" extension will be documented in this file.
 
+## [0.12.0] - 2023-08-30
+### Added
+* `haskutil.supportedDependencies` configuration option:  
+  Make the list of supported Haskell diagnostic generating extensions configurable
+
 ## [0.11.4] - 2023-08-27
 ### Fixed
 * `OrganizeExtensionProvider`: false positive of `Extension are unorganised`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "haskutil",
-  "version": "0.11.4",
+  "version": "0.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "haskutil",
-      "version": "0.11.4",
+      "version": "0.12.0",
       "license": "MIT",
       "devDependencies": {
         "@istanbuljs/nyc-config-typescript": "1.0.2",
@@ -42,12 +42,12 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.22.10",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.10.tgz",
-      "integrity": "sha512-/KKIMG4UEL35WmI9OlvMhurwtytjvXoFcGNrOvyG9zIzA8YmPjVtIZUf7b05+TPO7G7/GEmLHDaoCgACHl9hhA==",
+      "version": "7.22.13",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.13.tgz",
+      "integrity": "sha512-XktuhWlJ5g+3TJXc5upd9Ks1HutSArik6jf2eAjYFyIOf4ej3RN+184cZbzDvbPnuTJIUhPKKJE3cIsYTiAT3w==",
       "dev": true,
       "dependencies": {
-        "@babel/highlight": "^7.22.10",
+        "@babel/highlight": "^7.22.13",
         "chalk": "^2.4.2"
       },
       "engines": {
@@ -288,9 +288,9 @@
       }
     },
     "node_modules/@babel/highlight": {
-      "version": "7.22.10",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.10.tgz",
-      "integrity": "sha512-78aUtVcT7MUscr0K5mIEnkwxPE0MaxkR5RxRwuHaQ+JuU5AmTPhY+do2mdzVTnIJJpyBglql2pehuBIWHug+WQ==",
+      "version": "7.22.13",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.13.tgz",
+      "integrity": "sha512-C/BaXcnnvBCmHTpz/VGZ8jgtE2aYlW4hxDhseJAWZb7gqGM/qtCK6iZUb0TyKFf7BOUsBH7Q7fkRsDRhg1XklQ==",
       "dev": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.22.5",
@@ -302,9 +302,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.22.11",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.11.tgz",
-      "integrity": "sha512-R5zb8eJIBPJriQtbH/htEQy4k7E2dHWlD2Y2VT07JCzwYZHBxV5ZYtM0UhXSNMT74LyxuM+b1jdL7pSesXbC/g==",
+      "version": "7.22.13",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.13.tgz",
+      "integrity": "sha512-3l6+4YOvc9wx7VlCSw4yQfcBo01ECA8TicQfbnCPuCEpRQrf+gTUyGdxNw+pyTUyywp6JRD1w0YQs9TpBXYlkw==",
       "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -1009,9 +1009,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001523",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001523.tgz",
-      "integrity": "sha512-I5q5cisATTPZ1mc588Z//pj/Ox80ERYDfR71YnvY7raS/NOk8xXlZcB0sF7JdqaV//kOaa6aus7lRfpdnt1eBA==",
+      "version": "1.0.30001524",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001524.tgz",
+      "integrity": "sha512-Jj917pJtYg9HSJBF95HVX3Cdr89JUyLT4IZ8SvM5aDRni95swKgYi3TgYLH5hnGfPE/U1dg6IfZ50UsIlLkwSA==",
       "dev": true,
       "funding": [
         {
@@ -1411,9 +1411,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.503",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.503.tgz",
-      "integrity": "sha512-LF2IQit4B0VrUHFeQkWhZm97KuJSGF2WJqq1InpY+ECpFRkXd8yTIaTtJxsO0OKDmiBYwWqcrNaXOurn2T2wiA==",
+      "version": "1.4.505",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.505.tgz",
+      "integrity": "sha512-0A50eL5BCCKdxig2SsCXhpuztnB9PfUgRMojj5tMvt8O54lbwz3t6wNgnpiTRosw5QjlJB7ixhVyeg8daLQwSQ==",
       "dev": true
     },
     "node_modules/emoji-regex": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "haskutil",
   "displayName": "Haskutil",
   "description": "'QuickFix' actions for Haskell editor",
-  "version": "0.11.4",
+  "version": "0.12.0",
   "publisher": "Edka",
   "repository": {
     "url": "https://github.com/EduardSergeev/vscode-haskutil"
@@ -174,6 +174,37 @@
           "type": "boolean",
           "description": "Check if any of recommended VSCode extensions which generate Haskell diagnostics is installed",
           "default": true
+        },
+        "haskutil.supportedDependencies": {
+          "type": "array",
+          "description": "Supported Haskell diagnostic generating extensions",
+          "items": {
+            "type":"object",
+            "properties": {
+              "id": {
+                "title": "Extension id",
+                "type":"string"
+              },
+              "name": {
+                "title": "Extension name",
+                "type":"string"
+              }
+            }
+          },
+          "default": [
+            {
+              "id": "dramforever.vscode-ghc-simple",
+              "name": "GHC"
+            },{
+              "id": "Vans.haskero",
+              "name": "Haskero"
+            },{
+              "id": "ndmitchell.haskell-ghcid",
+              "name": "ghcid"
+            },{
+              "id": "digitalassetholdingsllc.ghcide",
+              "name": "ghcid"
+          }]
         }
       }
     }

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -15,6 +15,7 @@ const alwaysPadImportsSection = "alwaysPadImports";
 const sortImportsSection = "sortImports";
 const organizeImportsOnSaveSection = "organiseImportsOnSave";
 const checkDiagnosticsExtensionSection = "checkDiagnosticsExtension";
+const supportedDependenciesSection = "supportedDependencies";
 
 function root(): WorkspaceConfiguration {
   return vscode.workspace.getConfiguration(rootSection);
@@ -39,6 +40,7 @@ export default class Configuration {
   public static sortImportsSection = sortImportsSection;
   public static organizeImportsOnSaveSection = organizeImportsOnSaveSection;
   public static checkDiagnosticsExtensionSection = checkDiagnosticsExtensionSection;
+  public static supportedDependenciesSection = supportedDependenciesSection;
 
   public static get root(): WorkspaceConfiguration {
     return root();
@@ -90,5 +92,9 @@ export default class Configuration {
 
   public static get checkDiagnosticsExtension(): boolean {
     return get(checkDiagnosticsExtensionSection);
-  } 
+  }
+
+  public static get supportedDependencies(): [{ id: string, name: string }] {
+    return get(supportedDependenciesSection);
+  }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -38,22 +38,20 @@ export function activate(context: vscode.ExtensionContext) {
 }
 
 function checkDependencies() {
-  const dependencies = [
-    ['dramforever.vscode-ghc-simple', 'Simple GHC'],
-    ['Vans.haskero', 'Haskero'],
-    ['ndmitchell.haskell-ghcid', 'ghcid'],
-    ['digitalassetholdingsllc.ghcide', 'ghcide']
-  ];
-  if(!dependencies.find(([id]) => vscode.extensions.getExtension(id))) {
-    const toLink = ([id, name]) => `[${name}](https://marketplace.visualstudio.com/items?itemName=${id})`;
+  const dependencies = Configuration.supportedDependencies;
+  if(!dependencies.find(extension => vscode.extensions.getExtension(extension.id))) {
+    const toLink = ({id, name}) => `[${name}](https://marketplace.visualstudio.com/items?itemName=${id})`;
     const items = dependencies.map(toLink);
     const warningSetting = `${Configuration.rootSection}.${Configuration.checkDiagnosticsExtensionSection}`;
-    const warningLink = `[${warningSetting}](${vscode.Uri.parse(`command:workbench.action.openSettings?["${warningSetting}"]`)})`;
+    const warningLink = `[${Configuration.checkDiagnosticsExtensionSection}](${vscode.Uri.parse(`command:workbench.action.openSettings?["${warningSetting}"]`)})`;
+    const listSetting = `${Configuration.rootSection}.${Configuration.supportedDependenciesSection}`;
+    const listLink = `[${Configuration.supportedDependenciesSection}](${vscode.Uri.parse(`command:workbench.action.openSettings?["${listSetting}"]`)})`;
     vscode.window.showWarningMessage(`Dependency is not installed.
       Extension which populates diagnostics (Errors and Warnings) is not installed.
       Please install either ${items.slice(0, -1).join(', ')} or ${items.pop()}
-      to get the full set of QuickFix actions provided by ${toLink(['edka.haskutil','Haskutil'])}.  
-      If you use diagnostics from non-supported extension you can disable this warning via ${warningLink}
+      to get the full set of QuickFix actions provided by ${toLink({ id: 'edka.haskutil', name: 'Haskutil' })}.  
+      You can disable this warning in ${warningLink}
+      or can add any 3rd party extension to the list in ${listLink}.
     `);
   }  
 }


### PR DESCRIPTION
- Added: 
  - `haskutil.supportedDependencies` configuration option:  
    On start up the extension checks if there is any extension from this list which is installed. If not and `haskutil.checkDiagnosticsExtension` is set to `true` a warning window will be displayed.  
    Relates to: #56