### PR TITLE
Supported extension view link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Change Log
 All notable changes to the "Haskutil" extension will be documented in this file.
 
+## [0.12.2] - 2023-08-31
+### Changed
+* `Dependency not installed` warning message extension links:  
+  Instead of linking to extension's Marketplace page link to VSCode `EXTENSIONS` view  
+  Focused to linked extension via `workbench.extensions.search` command-link
+
 ## [0.12.1] - 2023-08-30
 ### Fixed
 * `CHANGELOG` formatting:  

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "haskutil",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "haskutil",
-      "version": "0.12.1",
+      "version": "0.12.2",
       "license": "MIT",
       "devDependencies": {
         "@istanbuljs/nyc-config-typescript": "1.0.2",
@@ -302,9 +302,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.22.13",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.13.tgz",
-      "integrity": "sha512-3l6+4YOvc9wx7VlCSw4yQfcBo01ECA8TicQfbnCPuCEpRQrf+gTUyGdxNw+pyTUyywp6JRD1w0YQs9TpBXYlkw==",
+      "version": "7.22.14",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.14.tgz",
+      "integrity": "sha512-1KucTHgOvaw/LzCVrEOAyXkr9rQlp0A1HiHRYnSUE9dmb8PvPW7o5sscg+5169r54n3vGlbx6GevTE/Iw/P3AQ==",
       "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -1411,9 +1411,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.505",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.505.tgz",
-      "integrity": "sha512-0A50eL5BCCKdxig2SsCXhpuztnB9PfUgRMojj5tMvt8O54lbwz3t6wNgnpiTRosw5QjlJB7ixhVyeg8daLQwSQ==",
+      "version": "1.4.506",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.506.tgz",
+      "integrity": "sha512-xxGct4GPAKSRlrLBtJxJFYy74W11zX6PO9GyHgl/U+2s3Dp0ZEwAklDfNHXOWcvH7zWMpsmgbR0ggEuaYAVvHA==",
       "dev": true
     },
     "node_modules/emoji-regex": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "haskutil",
   "displayName": "Haskutil",
   "description": "'QuickFix' actions for Haskell editor",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "publisher": "Edka",
   "repository": {
     "url": "https://github.com/EduardSergeev/vscode-haskutil"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -40,7 +40,7 @@ export function activate(context: vscode.ExtensionContext) {
 function checkDependencies() {
   const dependencies = Configuration.supportedDependencies;
   if(!dependencies.find(extension => vscode.extensions.getExtension(extension.id))) {
-    const toLink = ({id, name}) => `[${name}](https://marketplace.visualstudio.com/items?itemName=${id})`;
+    const toLink = ({id, name}) => `[${name}](${vscode.Uri.parse(`command:workbench.extensions.search?["@id:${id}"]`)})`;
     const items = dependencies.map(toLink);
     const warningSetting = `${Configuration.rootSection}.${Configuration.checkDiagnosticsExtensionSection}`;
     const warningLink = `[${Configuration.checkDiagnosticsExtensionSection}](${vscode.Uri.parse(`command:workbench.action.openSettings?["${warningSetting}"]`)})`;


### PR DESCRIPTION
- Changed:
  - Use command-links for links to other extensions:
    In `Dependency is not installed` warning message notification  
    Instead of linking to extension's Marketplace page link to VSCode `EXTENSIONS` view focused to the linked extension via `workbench.extensions.search` command-link