### PR TITLE
Fix intermittent `Cancelled` tests failure

### DIFF
--- a/input/Welcome.hs
+++ b/input/Welcome.hs
@@ -1,4 +1,1 @@
-
-foo :: Ord a => [a] -> Maybe [a]
-foo xs =
-  listToMaybe . tails. sort $ xs 
+main = putStrLn "Hello World"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "haskutil",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "haskutil",
-      "version": "0.13.0",
+      "version": "0.13.1",
       "license": "MIT",
       "devDependencies": {
         "@istanbuljs/nyc-config-typescript": "1.0.2",
         "@types/chai": "4.3.16",
         "@types/mocha": "10.0.6",
-        "@types/node": "20.12.10",
+        "@types/node": "20.12.11",
         "@types/vscode": "1.48.0",
         "@vscode/test-electron": "2.3.9",
         "@vscode/vsce": "2.26.1",
@@ -845,9 +845,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.12.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.10.tgz",
-      "integrity": "sha512-Eem5pH9pmWBHoGAT8Dr5fdc5rYA+4NAovdM4EktRPVAAiJhmWWfQrA0cFhAbOsQdSfIHjAud6YdkbL69+zSKjw==",
+      "version": "20.12.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.11.tgz",
+      "integrity": "sha512-vDg9PZ/zi+Nqp6boSOT7plNuthRugEKixDv5sFTIpkE89MmNtEArAShI4mxuX2+UrLEe9pxC1vm2cjm9YlWbJw==",
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
@@ -1289,9 +1289,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001616",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001616.tgz",
-      "integrity": "sha512-RHVYKov7IcdNjVHJFNY/78RdG4oGVjbayxv8u5IO74Wv7Hlq4PnJE6mo/OjFijjVFNy5ijnCt6H3IIo4t+wfEw==",
+      "version": "1.0.30001617",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001617.tgz",
+      "integrity": "sha512-mLyjzNI9I+Pix8zwcrpxEbGlfqOkF9kM3ptzmKNw5tizSyYwMe+nGLTqMK9cO+0E+Bh6TsBxNAaHWEM8xwSsmA==",
       "dev": true,
       "funding": [
         {
@@ -1759,9 +1759,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.759",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.759.tgz",
-      "integrity": "sha512-qZJc+zsuI+/5UjOSFnpkJBwwLMH1AZgyKqJ7LUNnRsB7v/cDjMu9DvXgp9kH6PTTZxjnPXGp2Uhurw+2Ll4Hjg==",
+      "version": "1.4.761",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.761.tgz",
+      "integrity": "sha512-PIbxpiJGx6Bb8dQaonNc6CGTRlVntdLg/2nMa1YhnrwYOORY9a3ZgGN0UQYE6lAcj/lkyduJN7BPt/JiY+jAQQ==",
       "dev": true
     },
     "node_modules/emoji-regex": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "haskutil",
   "displayName": "Haskutil",
   "description": "'QuickFix' actions for Haskell editor",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "publisher": "Edka",
   "icon": "images/Haskutil-logo.png",
   "repository": {
@@ -256,7 +256,7 @@
     "@istanbuljs/nyc-config-typescript": "1.0.2",
     "@types/chai": "4.3.16",
     "@types/mocha": "10.0.6",
-    "@types/node": "20.12.10",
+    "@types/node": "20.12.11",
     "@types/vscode": "1.48.0",
     "@vscode/vsce": "2.26.1",
     "@vscode/test-electron": "2.3.9",

--- a/src/features/extensionProvider.ts
+++ b/src/features/extensionProvider.ts
@@ -2,7 +2,6 @@ import * as vscode from 'vscode';
 import { CodeActionProvider, Disposable, TextDocument, Range, CodeActionContext, CancellationToken, CodeAction, WorkspaceEdit, CodeActionKind } from 'vscode';
 import OrganizeExtensionProvider from './organizeExtensionProvider';
 import Configuration from '../configuration';
-import { promisify } from 'util';
 
 
 export default class ExtensionProvider implements CodeActionProvider {

--- a/src/test/utils.ts
+++ b/src/test/utils.ts
@@ -63,16 +63,16 @@ export async function runQuickFixes(quickFixes: CodeAction[]) {
 
 export async function didChangeDiagnostics<T>(fsPath: string, [severety, count]: [DiagnosticSeverity, number], action: () => Thenable<T>) {
     return didEvent(
-    vscode.languages.onDidChangeDiagnostics,
-    e => {
-      const uri = e.uris.find(uri => uri.fsPath === fsPath);
-      const diags = vscode.languages.getDiagnostics(uri).filter(d => d.severity <= severety);
-      assert.isAtMost(diags.length, count);
-      return uri && diags.length === count;
-    },
-    action);
+      vscode.languages.onDidChangeDiagnostics,
+      e => {
+        const uri = e.uris.find(uri => uri.fsPath === fsPath);
+        const diags = vscode.languages.getDiagnostics(uri).filter(d => d.severity <= severety);
+        assert.isAtMost(diags.length, count);
+        return uri && diags.length === count;
+      },
+      action,
+    );
 }
-
 
 export async function didEvent<TResult, TEvent>(
   subscribe: (arg: (event: TEvent) => void) => Disposable,


### PR DESCRIPTION
- Fixed:
  - Fix `Cancelled` test failures:  
    The intermittent test failures which output "Cancelled" in failure stack trace.  
    More like a hack at this point but adding `Sleep` in test initialisation function seems to fixes this issue. Looks like VSCode + extension(s) need some time to initialise properly but I could not find any suitable event for that to wait for instead. 