### PR TITLE
Various bug fixes

### DIFF
--- a/.github/workflows/branch.yml
+++ b/.github/workflows/branch.yml
@@ -16,10 +16,7 @@ jobs:
         node-version: 20
 
     - name: Set up GHC environment
-      run: |
-        echo "resolver: ghc-9.4.5" > stack.yaml
-        echo "packages: []" >> stack.yaml
-        stack setup
+      run: stack setup
   
     - run: npm install
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,20 @@
 # Change Log
 All notable changes to the "Haskutil" extension will be documented in this file.
 
+## [0.13.2] - 2024-05-19
+### Fixed
+* `Remove unused imports` action when import declaration contains elements with `(..)` ([#40](https://github.com/EduardSergeev/vscode-haskutil/issues/40)):  
+  Fix behaviour of `RemoveUnusedImportProvider` in regards to removal from import lists containing elements with export lists, e.g. `Sum(..)` or `Sum(fromSum)`;
+* `Replace wildcard` action under GHC 9.6.5 ([#79](https://github.com/EduardSergeev/vscode-haskutil/issues/79)):  
+  Fix `TypeWildcardProvider` behavior when running with latest GHC handling changes in corresponding GHC error message format;
+### Changed
+* Switch `branch` CI build to run tests against the latest GHC
+
 ## [0.13.1] - 2024-05-11
 ### Fixed
 * Intermittent test failures  
-  Failures with "Cancelled" error message
-* CHANELOG formatting
+  Failures with `Cancelled` error message
+* `CHANELOG` formatting
 
 ## [0.13.0] - 2024-05-07
 ### Added

--- a/input/after/UnusedImportProvider.hs
+++ b/input/after/UnusedImportProvider.hs
@@ -1,5 +1,12 @@
 import Data.List (sort)
+import Data.Monoid (Product(getProduct), Sum(..))
 
 foo :: Ord a => [a] -> [a]
 foo xs =
   sort xs 
+
+sum :: Sum a -> a
+sum = getSum 
+
+product :: Product a -> a
+product = getProduct

--- a/input/before/UnusedImportProvider.hs
+++ b/input/before/UnusedImportProvider.hs
@@ -1,6 +1,13 @@
 import Data.List (sort, tails)
 import Data.Maybe
+import Data.Monoid (All(..), Any(getAny), Product(getProduct), Sum(..))
 
 foo :: Ord a => [a] -> [a]
 foo xs =
   sort xs 
+
+sum :: Sum a -> a
+sum = getSum 
+
+product :: Product a -> a
+product = getProduct

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "haskutil",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "haskutil",
-      "version": "0.13.1",
+      "version": "0.13.2",
       "license": "MIT",
       "devDependencies": {
         "@istanbuljs/nyc-config-typescript": "1.0.2",
         "@types/chai": "4.3.16",
         "@types/mocha": "10.0.6",
-        "@types/node": "20.12.11",
+        "@types/node": "20.12.12",
         "@types/vscode": "1.48.0",
         "@vscode/test-electron": "2.3.9",
         "@vscode/vsce": "2.26.1",
@@ -845,9 +845,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.12.11",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.11.tgz",
-      "integrity": "sha512-vDg9PZ/zi+Nqp6boSOT7plNuthRugEKixDv5sFTIpkE89MmNtEArAShI4mxuX2+UrLEe9pxC1vm2cjm9YlWbJw==",
+      "version": "20.12.12",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.12.tgz",
+      "integrity": "sha512-eWLDGF/FOSPtAvEqeRAQ4C8LSA7M1I7i0ky1I8U7kD1J5ITyW3AsRhQrKVoWf5pFKZ2kILsEGJhsI9r93PYnOw==",
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "haskutil",
   "displayName": "Haskutil",
   "description": "'QuickFix' actions for Haskell editor",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "publisher": "Edka",
   "icon": "images/Haskutil-logo.png",
   "repository": {
@@ -256,7 +256,7 @@
     "@istanbuljs/nyc-config-typescript": "1.0.2",
     "@types/chai": "4.3.16",
     "@types/mocha": "10.0.6",
-    "@types/node": "20.12.11",
+    "@types/node": "20.12.12",
     "@types/vscode": "1.48.0",
     "@vscode/vsce": "2.26.1",
     "@vscode/test-electron": "2.3.9",

--- a/src/features/importProvider/importDeclaration.ts
+++ b/src/features/importProvider/importDeclaration.ts
@@ -70,12 +70,14 @@ export default class ImportDeclaration {
 
   public removeElement(elem: string) {
     const before = this.importElements;
-    const index = this.importNames.findIndex(oldElem => oldElem === elem);
-    this._importElements.splice(index, 1);
-    if(index === 0 && this._importElements.length > 0) {
-      this._importElements[0] = this._importElements[0].trimLeft();
+    const index = this.importNames.findIndex(oldElem => oldElem === elem || oldElem == `${elem}(..)`);
+    if (index !== -1) {
+      this._importElements.splice(index, 1);
+      if(index === 0 && this._importElements.length > 0) {
+        this._importElements[0] = this._importElements[0].trimStart();
+      }
+      this.importList = this.importList.replace(before, this.importElements);
     }
-    this.importList = this.importList.replace(before, this.importElements);
   }
 
   public get text() {

--- a/src/features/removeUnusedImportProvider.ts
+++ b/src/features/removeUnusedImportProvider.ts
@@ -93,7 +93,7 @@ export default class RemoveUnusedImportProvider implements CodeActionProvider {
     return diagnostics
       .map(d => [
         d.range,
-        d.message.match(/The (qualified )?import of (?:[`‘](.+?)['’]\s+from module )?[`‘](.+?)['’] is redundant/m)
+        d.message.match(/The (qualified )?import of (?:[`‘]([\s\S]+?)['’]\s+from module )?[`‘](.+?)['’] is redundant/m)
       ] as const)
       .filter(([,m]) => m)
       .map(([range, match]) => [

--- a/src/features/typeWildcardProvider.ts
+++ b/src/features/typeWildcardProvider.ts
@@ -40,7 +40,7 @@ export default class TypeWildcardProvider implements CodeActionProvider {
         }
 
         const line = document.lineAt(diagnostic.range.start);
-        if(fill === "()") {
+        if(fill === "()" || fill == "() :: Constraint") {
           fill = "";
           const wilcardMatch = line.text.match(/_\s*=>\s*/) || line.text.match(/,\s*_\s*/) || line.text.match(/\s*_\s*,/);
           if(wilcardMatch) {

--- a/src/test/providers.test.ts
+++ b/src/test/providers.test.ts
@@ -57,7 +57,7 @@ suite('', () => {
   });  
   
   test('Remove unused imports', () => {
-    return runQuickfixTest('UnusedImportProvider.hs', 2);
+    return runQuickfixTest('UnusedImportProvider.hs', 3);
   });
   
   test('Add missing extension', () => {


### PR DESCRIPTION
- Fixed:
  - "Remove unused imports" when import declaration contains elements with `(..)` (Closes #40):  
     Fix behaviour of `RemoveUnusedImportProvider` in regards to removal from import lists containing elements with export lists, e.g. `Sum(..)` or `Sum(fromSum)`;
  - "Replace wildcard" under GHC 9.6.5 (Closes #79):  
    Fix `TypeWildcardProvider` behavior when running with latest GHC by handling changes in corresponding GHC error message format;
- Changed:
  - Switch `branch` CI build to run tests against the latest GHC:  
    Since #79 is now fixed
